### PR TITLE
Update publications

### DIFF
--- a/content/keaven.bib
+++ b/content/keaven.bib
@@ -9,6 +9,15 @@
   publisher = {Am Heart Assoc}
 }
 
+@article{aguirre1996clinical,
+  title   = {Clinical Benefit within Patient Subgroups Receiving {c7E3} {Fab} (Abciximab) During Percutaneous Coronary Revascularization: Subgroup Analysis from the {EPIC} Trial.},
+  author  = {Aguirre, Frank V and Topol, Eric J and Anderson, Keaven M and Kleiman, Neal S and Weisman, Harlan F and FitzPatrick, Susan E and Califf, Robert M},
+  journal = {The Journal of Invasive Cardiology},
+  volume  = {8},
+  pages   = {21B--29B},
+  year    = {1996}
+}
+
 @inproceedings{aguirre1997impact,
   title        = {Impact of contrast media on clinical outcomes following percutaneous coronary interventions with platelet glycoprotein {IIb}/{IIIa} inhibition: meta-analysis of clinical trials with abciximab},
   author       = {Aguirre, FV and Simoons, ML and Ferguson, JJ and FitzPatrick, SE and Anderson, KM and Kern, MJ and Tcheng, JE},
@@ -28,7 +37,24 @@
   number    = {1},
   pages     = {78--82},
   year      = {2001},
-  publisher = {American Medical Association}
+  publisher = {American Medical Association},
+  doi       = {10.1001/jama.286.1.78}
+}
+
+@book{anderson1980multivariate,
+  title     = {Multivariate hypergeometric and multinomial waiting times},
+  author    = {Anderson, Keaven and Sobel, Milton and Uppuluri, VRR},
+  year      = {1980},
+  publisher = {Stanford University. Department of Statistics},
+  url       = {https://purl.stanford.edu/gt383hn1006}
+}
+
+@techreport{anderson1982moment,
+  title       = {Moment expansions for robust statistics},
+  author      = {Anderson, Keaven M},
+  year        = {1982},
+  institution = {Stanford University. Department of Statistics},
+  url         = {https://purl.stanford.edu/sn138ps6683}
 }
 
 @article{anderson1982quota,
@@ -39,11 +65,12 @@
   number    = {2},
   pages     = {73--88},
   year      = {1982},
-  publisher = {Wiley Online Library}
+  publisher = {Wiley Online Library},
+  doi       = {10.2307/3314900}
 }
 
 @article{anderson1983longitudinal,
-  title   = {Longitudinal and secular trends in lipoproteins: the Framingham Offspring Study},
+  title   = {Longitudinal and secular trends in lipoproteins: the {Framingham Offspring Study}},
   author  = {Anderson, KM and Wilson, PWF and Garrison, RJ and Castelli, WP},
   journal = {Arterioscler Thromb},
   volume  = {3},
@@ -51,26 +78,38 @@
   year    = {1983}
 }
 
+@inproceedings{anderson1986repeated,
+  title     = {Repeated measures of body-mass index and mortality---the {Framingham} study},
+  author    = {Anderson, KM and Castelli, WP and Stokes, J},
+  booktitle = {AMERICAN JOURNAL OF EPIDEMIOLOGY},
+  volume    = {124},
+  number    = {3},
+  pages     = {514--514},
+  year      = {1986}
+}
+
 @article{anderson1987cholesterol,
-  title     = {Cholesterol and mortality: 30 years of follow-up from the Framingham Study},
+  title     = {Cholesterol and mortality: 30 years of follow-up from the {Framingham Study}},
   author    = {Anderson, Keaven M and Castelli, William P and Levy, Daniel},
   journal   = {JAMA},
   volume    = {257},
   number    = {16},
   pages     = {2176--2180},
   year      = {1987},
-  publisher = {American Medical Association}
+  publisher = {American Medical Association},
+  doi       = {10.1001/jama.1987.03390160062027}
 }
 
 @article{anderson1987longitudinal,
-  title     = {Longitudinal and secular trends in lipoprotein cholesterol measurements in a general population sample The Framingham Offspring Study},
+  title     = {Longitudinal and secular trends in lipoprotein cholesterol measurements in a general population sample {The Framingham Offspring Study}},
   author    = {Anderson, Keaven M and Wilson, Peter WF and Garrison, Robert J and Castelli, William P},
   journal   = {Atherosclerosis},
   volume    = {68},
   number    = {1-2},
   pages     = {59--66},
   year      = {1987},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/0021-9150(87)90094-3}
 }
 
 @article{anderson1991cardiovascular,
@@ -81,16 +120,26 @@
   number    = {1},
   pages     = {293--298},
   year      = {1991},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/0002-8703(91)90861-b}
+}
+
+@incollection{anderson1991management,
+  title     = {Management of data quality in a long-term epidemiologic study: The {Framingham Heart Study}},
+  author    = {Anderson, Keaven M and Dumphy, Deborah C and Wilson, Peter WF},
+  booktitle = {Data quality control theory and pragmatics},
+  pages     = {57--68},
+  year      = {1991}
 }
 
 @article{anderson1991nonproportional,
-  title     = {A nonproportional hazards Weibull accelerated failure time regression model},
+  title     = {A nonproportional hazards {Weibull} accelerated failure time regression model},
   author    = {Anderson, Keaven M},
   journal   = {Biometrics},
   pages     = {281--288},
   year      = {1991},
-  publisher = {JSTOR}
+  publisher = {JSTOR},
+  doi       = {10.2307/2532512}
 }
 
 @article{anderson1991updated,
@@ -115,6 +164,16 @@
   pages     = {465--473}
 }
 
+@article{anderson1999industry,
+  title   = {An industry perspective on health economics studies},
+  author  = {Anderson, Keaven M and Bala, Mohan V and Weisman, Harlan F},
+  journal = {The American heart journal},
+  volume  = {137},
+  number  = {5},
+  pages   = {S129--S132},
+  year    = {1999}
+}
+
 @article{anderson2001long,
   title     = {Long-term mortality benefit with abciximab in patients undergoing percutaneous coronary intervention},
   author    = {Anderson, Keaven M and Califf, Robert M and Stone, Gregg W and Neumann, Franz-Josef and Montalescot, Gilles and Miller, Dave P and Ferguson, James J and Willerson, James T and Weisman, Harlan F and Topol, Eric J},
@@ -123,7 +182,8 @@
   number    = {8},
   pages     = {2059--2065},
   year      = {2001},
-  publisher = {American College of Cardiology Foundation Washington, DC}
+  publisher = {American College of Cardiology Foundation Washington, DC},
+  doi       = {10.1016/s0735-1097(01)01290-6}
 }
 
 @article{anderson2007optimal,
@@ -134,7 +194,8 @@
   number    = {3},
   pages     = {337--345},
   year      = {2007},
-  publisher = {Wiley Online Library}
+  publisher = {Wiley Online Library},
+  doi       = {10.1002/bimj.200510205}
 }
 
 @article{anderson2010fitting,
@@ -145,7 +206,39 @@
   number    = {3},
   pages     = {321--327},
   year      = {2010},
-  publisher = {Wiley Online Library}
+  publisher = {Wiley Online Library},
+  doi       = {10.1002/sim.3737}
+}
+
+@article{anderson2012adaptive,
+  title     = {An adaptive design for case-driven vaccine efficacy study when incidence rate is unknown},
+  author    = {Anderson, Keaven M and Chan, Ivan SF and Li, Xiaoming},
+  journal   = {Statistics and its Interface},
+  volume    = {5},
+  number    = {4},
+  pages     = {391--399},
+  year      = {2012},
+  publisher = {International Press of Boston},
+  doi       = {10.4310/SII.2012.v5.n4.a2}
+}
+
+@incollection{anderson2014timing,
+  title     = {Timing and frequency of interim analyses in confirmatory trials},
+  author    = {Anderson, Keaven M},
+  booktitle = {Practical considerations for adaptive trial design and implementation},
+  pages     = {115--123},
+  year      = {2014},
+  publisher = {Springer},
+  doi       = {10.1007/978-1-4939-1100-4_6}
+}
+
+@article{anderson2022unified,
+  title     = {A unified framework for weighted parametric group sequential design},
+  author    = {Anderson, Keaven M and Guo, Zifang and Zhao, Jing and Sun, Linda Z},
+  journal   = {Biometrical Journal},
+  year      = {2022},
+  publisher = {Wiley Online Library},
+  doi       = {10.1002/bimj.202100085}
 }
 
 @article{antman1998abciximab,
@@ -178,7 +271,8 @@
   number    = {23},
   pages     = {1944--1953},
   year      = {2000},
-  publisher = {Oxford University Press}
+  publisher = {Oxford University Press},
+  doi       = {10.1053/euhj.2000.2243}
 }
 
 @article{antman2002determinants,
@@ -189,11 +283,12 @@
   number    = {12},
   pages     = {928--933},
   year      = {2002},
-  publisher = {Oxford University Press}
+  publisher = {Oxford University Press},
+  doi       = {10.1053/euhj.2001.2964}
 }
 
 @article{ballard1990body,
-  title     = {Body fat distribution and breast cancer in the Framingham Study},
+  title     = {Body fat distribution and breast cancer in the {Framingham Study}},
   author    = {Ballard-Barbash, Rachel and Schatzkin, Arthur and Carter, Christine L and Kannel, William B and Kreger, Bernard E and D'Agostino, Ralph B and Splansky, Greta L and Anderson, Keaven M and Helsel, William E},
   journal   = {JNCI: Journal of the National Cancer Institute},
   volume    = {82},
@@ -204,7 +299,7 @@
 }
 
 @article{ballard1990physical,
-  title     = {Physical activity and risk of large bowel cancer in the Framingham Study},
+  title     = {Physical activity and risk of large bowel cancer in the {Framingham Study}},
   author    = {Ballard-Barbash, Rachel and Schatzkin, Arthur and Albanes, Demetrius and Schiffman, Mark H and Kreger, Bernard E and Kannel, William B and Anderson, Keaven M and Helsel, William E},
   journal   = {Cancer Research},
   volume    = {50},
@@ -214,8 +309,29 @@
   publisher = {AACR}
 }
 
+@incollection{bautista2021sample,
+  title     = {Sample Size Estimation and Power Analysis: Time to Event Data},
+  author    = {Bautista, Oliver and Anderson, Keaven},
+  booktitle = {Handbook of Statistical Methods for Randomized Controlled Trials},
+  pages     = {275--300},
+  year      = {2021},
+  publisher = {Chapman and Hall/CRC},
+  doi       = {10.1201/9781315119694}
+}
+
+@article{benjamin1991impact,
+  title     = {The impact of age on left ventricular diastolic function in healthy subjects from the {Framingham Heart Study}},
+  author    = {Benjamin, Emelia J and Anderson, Keaven M and Plehn, Jonathan F and Comai, Kathy and Fuller, Deborah and Evans, Jane C and Wolf, Philip A and Sutton, Martin St John and Levy, Daniel},
+  journal   = {Journal of the American College of Cardiology},
+  volume    = {17},
+  number    = {2S1},
+  pages     = {A329--A329},
+  year      = {1991},
+  publisher = {American College of Cardiology Foundation Washington, DC}
+}
+
 @article{benjamin1992determinants,
-  title     = {Determinants of Doppler indexes of left ventricular diastolic function in normal subjects (the Framingham Heart Study)},
+  title     = {Determinants of Doppler indexes of left ventricular diastolic function in normal subjects (the {Framingham Heart Study})},
   author    = {Benjamin, Emelia J and Levy, Daniel and Anderson, Keaven M and Wolf, Philip A and Plehn, Jonathan F and Evans, Jane C and Comai, Kathy and Fuller, Deborah L and Sutton, Martin St John},
   journal   = {The American Journal of Cardiology},
   volume    = {70},
@@ -247,6 +363,17 @@
   publisher = {American Medical Association}
 }
 
+@inproceedings{blankenship1997decreased,
+  title        = {Decreased vascular access site bleeding after coronary intervention with abciximab in the {EPILOG} vs the {EPIC} trial},
+  author       = {Blankenship, JC and Anderson, KM and Demko, L and Cabot, CF and Kereiakes, DJ and Aguirre, FV},
+  booktitle    = {Circulation},
+  volume       = {96},
+  number       = {8},
+  pages        = {896--896},
+  year         = {1997},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
 @article{bohula2018effect,
   title     = {Effect of lorcaserin on prevention and remission of type 2 diabetes in overweight and obese patients ({CAMELLIA-TIMI} 61): a randomised, placebo-controlled trial},
   author    = {Bohula, Erin A and Scirica, Benjamin M and Inzucchi, Silvio E and McGuire, Darren K and Keech, Anthony C and Smith, Steven R and Kanevsky, Estella and Murphy, Sabina A and Leiter, Lawrence A and Dwyer, Jamie P and others},
@@ -255,20 +382,23 @@
   number    = {10161},
   pages     = {2269--2279},
   year      = {2018},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/S0140-6736(18)32328-6}
 }
 
 @article{capture1997randomized,
-  title   = {Randomized placebo-controlled trial of abciximab before and during coronary intervention in refractory angina: the {CAPTURE} study.},
-  author  = {{CAPTURE Investigators and others}},
-  journal = {Lancet},
+  title   = {Randomised placebo-controlled trial of abciximab before and during coronary intervention in refractory unstable angina: the {CAPTURE} study},
+  author  = {{The CAPTURE Investigators}},
+  journal = {The Lancet},
   volume  = {349},
-  pages   = {1429--1435},
-  year    = {1997}
+  number  = {9063},
+  pages   = {1429-1435},
+  year    = {1997},
+  doi     = {10.1016/S0140-6736(96)10452-9}
 }
 
 @article{castelli1986population,
-  title     = {A population at risk: prevalence of high cholesterol levels in hypertensive patients in the Framingham Study},
+  title     = {A population at risk: prevalence of high cholesterol levels in hypertensive patients in the {Framingham Study}},
   author    = {Castelli, William P and Anderson, Keaven},
   journal   = {The American Journal of Medicine},
   volume    = {80},
@@ -290,14 +420,27 @@
 }
 
 @article{castelli1992lipids,
-  title     = {Lipids and risk of coronary heart disease The Framingham Study},
+  title     = {Lipids and risk of coronary heart disease {The Framingham Study}},
   author    = {Castelli, William P and Anderson, Keaven and Wilson, Peter WF and Levy, Daniel},
   journal   = {Annals of Epidemiology},
   volume    = {2},
   number    = {1-2},
   pages     = {23--28},
   year      = {1992},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/1047-2797(92)90033-m}
+}
+
+@article{chen2010minipool,
+  title     = {A ``MiniPool'' approach for combined Phase {IIB}/{III} trial in patients with life-threatening disease: an application of the closed testing principle},
+  author    = {Chen, YH Joshua and Anderson, Keaven M},
+  journal   = {Statistics in Biopharmaceutical Research},
+  volume    = {2},
+  number    = {1},
+  pages     = {62--71},
+  year      = {2010},
+  publisher = {Taylor \& Francis},
+  doi       = {10.1198/sbr.2009.0038}
 }
 
 @article{chen20182,
@@ -307,7 +450,19 @@
   volume    = {64},
   pages     = {238--242},
   year      = {2018},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/j.cct.2017.09.006}
+}
+
+@article{chen2021multiplicity,
+  title     = {Multiplicity for a group sequential trial with biomarker subpopulations},
+  author    = {Chen, Ting-Yu and Zhao, Jing and Sun, Linda and Anderson, Keaven M},
+  journal   = {Contemporary Clinical Trials},
+  volume    = {101},
+  pages     = {106249},
+  year      = {2021},
+  publisher = {Elsevier},
+  doi       = {10.1016/j.cct.2020.106249}
 }
 
 @article{chuang2006sample,
@@ -318,7 +473,8 @@
   number    = {4},
   pages     = {475--484},
   year      = {2006},
-  publisher = {Springer}
+  publisher = {Springer},
+  doi       = {10.1177/216847900604000413}
 }
 
 @article{cohen2007detection,
@@ -329,7 +485,8 @@
   number    = {18},
   pages     = {1366--1374},
   year      = {2007},
-  publisher = {Oxford University Press}
+  publisher = {Oxford University Press},
+  doi       = {10.1093/jnci/djm130}
 }
 
 @article{cole1994parametric,
@@ -363,8 +520,19 @@
   publisher = {Karger Publishers}
 }
 
+@inproceedings{coussement1999comparison,
+  title        = {Comparison of two different thrombolytic regimens with and without abciximab in {ST}-elevation myocardial infarction: Observations from the {TIMI} 14 trial},
+  author       = {Coussement, PK and Antman, EM and Giugliano, RP and McCabe, CH and Schuhwerk, KC and Gibson, M and Scherer, J and Anderson, K and Braunwald, E and Van de Werf, F},
+  booktitle    = {Circulation},
+  volume       = {100},
+  number       = {18},
+  pages        = {650--650},
+  year         = {1999},
+  organization = {LIPPINCOTT WILLIAMS \& WILKINS TWO COMMERCE SQ, 2001 MARKET ST, PHILADELPHIA~…}
+}
+
 @article{cupples1988comparison,
-  title     = {Comparison of baseline and repeated measure covariate techniques in the Framingham Heart Study},
+  title     = {Comparison of baseline and repeated measure covariate techniques in the {Framingham Heart Study}},
   author    = {Cupples, L Adrienne and D'Agostino, Ralph B and Anderson, Keaven and Kannel, William B},
   journal   = {Statistics in Medicine},
   volume    = {7},
@@ -375,7 +543,7 @@
 }
 
 @article{d1990relation,
-  title     = {Relation of pooled logistic regression to time dependent Cox regression analysis: the Framingham Heart Study},
+  title     = {Relation of pooled logistic regression to time dependent {Cox} regression analysis: the {Framingham Heart Study}},
   author    = {D'Agostino, Ralph B and Lee, Mei-Ling and Belanger, Albert J and Cupples, L Adrienne and Anderson, Keaven and Kannel, William B},
   journal   = {Statistics in Medicine},
   volume    = {9},
@@ -393,7 +561,8 @@
   number    = {3},
   pages     = {239--243},
   year      = {2000},
-  publisher = {Am Heart Assoc}
+  publisher = {Am Heart Assoc},
+  doi       = {10.1161/01.cir.101.3.239}
 }
 
 @article{ellis1993safety,
@@ -414,7 +583,8 @@
   number    = {14},
   pages     = {956--961},
   year      = {1994},
-  publisher = {Mass Medical Soc}
+  publisher = {Mass Medical Soc},
+  doi       = {10.1056/NEJM199404073301402}
 }
 
 @article{epilog1997platelet,
@@ -425,11 +595,12 @@
   number    = {24},
   pages     = {1689--1697},
   year      = {1997},
-  publisher = {Mass Medical Soc}
+  publisher = {Mass Medical Soc},
+  doi       = {10.1056/NEJM199706123362401}
 }
 
 @article{galderisi1991echocardiographic,
-  title     = {Echocardiographic evidence for the existence of a distinct diabetic cardiomyopathy (the Framingham Heart Study)},
+  title     = {Echocardiographic evidence for the existence of a distinct diabetic cardiomyopathy (the {Framingham Heart Study})},
   author    = {Galderisi, Maurizio and Anderson, Keaven M and Wilson, Peter WF and Levy, Daniel},
   journal   = {The American Journal of Cardiology},
   volume    = {68},
@@ -447,7 +618,8 @@
   number    = {3},
   pages     = {275--283},
   year      = {2006},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/10543400600614742}
 }
 
 @article{gallo2010viewpoints,
@@ -458,7 +630,8 @@
   number    = {6},
   pages     = {1115--1124},
   year      = {2010},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/10543406.2010.514452}
 }
 
 @article{gaydos2009good,
@@ -469,7 +642,8 @@
   number    = {5},
   pages     = {539--556},
   year      = {2009},
-  publisher = {SAGE Publications Sage CA: Los Angeles, CA}
+  publisher = {SAGE Publications Sage CA: Los Angeles, CA},
+  doi       = {10.1177/009286150904300503}
 }
 
 @article{genest1992lipoprotein,
@@ -494,6 +668,17 @@
   organization = {LIPPINCOTT WILLIAMS \& WILKINS TWO COMMERCE SQ, 2001 MARKET ST, PHILADELPHIA}
 }
 
+@article{goetzler1985prognosis,
+  title     = {Prognosis of subjects in the {Framingham Study} with rheumatic heart disease},
+  author    = {Goetzler, Renee and Stokes III, Joseph and Anderson, Keaven},
+  journal   = {Journal of the American Geriatrics Society},
+  volume    = {33},
+  number    = {10},
+  pages     = {693--697},
+  year      = {1985},
+  publisher = {Wiley Online Library}
+}
+
 @inproceedings{gold1997randomized,
   title        = {A randomized, placebo-controlled crossover trial of {ReoPro} alone or combined with low-dose plasminogen activator for coronary reperfusion in patients with acute myocardial infarction: preliminary results},
   author       = {Gold, HK and Kereiakes, DJ and Dinsmore, RE and Martin, LH and Lausten, D and Broderick, TM and Anderson, KM and Garabedian, HD and Leinbach, RC},
@@ -506,7 +691,7 @@
 }
 
 @article{goldberg1991duration,
-  title     = {Duration of the {QT} interval and total and cardiovascular mortality in healthy persons (The Framingham Heart Study experience)},
+  title     = {Duration of the {QT} interval and total and cardiovascular mortality in healthy persons ({The Framingham Heart Study} experience)},
   author    = {Goldberg, Robert J and Bengtson, James and Chen, Zuoyao and Anderson, Keaven M and Locati, Emanuela and Levy, Daniel},
   journal   = {The American Journal of Cardiology},
   volume    = {67},
@@ -514,6 +699,17 @@
   pages     = {55--58},
   year      = {1991},
   publisher = {Elsevier}
+}
+
+@article{greipp1989phase,
+  title     = {Phase {II} trial of amsacrine in patients with multiple myeloma},
+  author    = {Greipp, Philip R and Coleman, Morton and Anderson, Keaven and McIntyre, O Ross},
+  journal   = {Medical and pediatric oncology},
+  volume    = {17},
+  number    = {1},
+  pages     = {76--78},
+  year      = {1989},
+  publisher = {Wiley Online Library}
 }
 
 @article{hands1988silent,
@@ -535,18 +731,20 @@
   number    = {2},
   pages     = {160--174},
   year      = {2012},
-  publisher = {Springer}
+  publisher = {Springer},
+  doi       = {10.1177/0092861512436580}
 }
 
 @book{he2014practical,
   title     = {Practical considerations for adaptive trial design and implementation},
   author    = {He, Weili and Pinheiro, Jos{\'e} and Kuznetsova, Olga M},
   year      = {2014},
-  publisher = {Springer}
+  publisher = {Springer},
+  doi       = {10.1007/978-1-4939-1100-4}
 }
 
 @article{ho1993survival,
-  title     = {Survival after the onset of congestive heart failure in Framingham Heart Study subjects.},
+  title     = {Survival after the onset of congestive heart failure in {Framingham Heart Study} subjects},
   author    = {Ho, KK and Anderson, Keaven M and Kannel, William B and Grossman, William and Levy, Daniel},
   journal   = {Circulation},
   volume    = {88},
@@ -568,7 +766,7 @@
 }
 
 @article{jones1990prognostic,
-  title     = {Prognostic use of a QRS scoring system after hospital discharge for initial acute myocardial infarction in the Framingham cohort},
+  title     = {Prognostic use of a QRS scoring system after hospital discharge for initial acute myocardial infarction in the {Framingham} cohort},
   author    = {Jones, Michael G and Anderson, Keaven M and Wilson, Peter WF and Kannel, William B and Wagner, Nancy B and Wagner, Galen S},
   journal   = {The American Journal of Cardiology},
   volume    = {66},
@@ -585,7 +783,8 @@
   volume  = {32},
   number  = {15\_suppl},
   pages   = {3015--3015},
-  year    = {2014}
+  year    = {2014},
+  doi     = {10.1200/jco.2014.32.15_suppl.3015}
 }
 
 @article{joseph2018baseline,
@@ -596,7 +795,8 @@
   number    = {20},
   pages     = {4960--4967},
   year      = {2018},
-  publisher = {AACR}
+  publisher = {AACR},
+  doi       = {10.1158/1078-0432.CCR-17-2386}
 }
 
 @article{joseph2018correction,
@@ -607,22 +807,24 @@
   number    = {23},
   pages     = {6098--6098},
   year      = {2018},
-  publisher = {AACR}
+  publisher = {AACR},
+  doi       = {10.1158/1078-0432.CCR-18-3340}
 }
 
 @article{kannel1987nonspecific,
-  title     = {Nonspecific electrocardiographic abnormality as a predictor of coronary heart disease: the Framingham Study},
+  title     = {Nonspecific electrocardiographic abnormality as a predictor of coronary heart disease: the {Framingham Study}},
   author    = {Kannel, William B and Anderson, Keaven and McGee, Daniel L and Degatano, Linda S and Stampfer, Meir J},
   journal   = {American Heart Journal},
   volume    = {113},
   number    = {2},
   pages     = {370--376},
   year      = {1987},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/0002-8703(87)90280-8}
 }
 
 @article{kannel1992relevance,
-  title   = {Relevance of blood lipids in the elderly: the Framingham Study},
+  title   = {Relevance of blood lipids in the elderly: the {Framingham Study}},
   author  = {Kannel, WB and Anderson, KM and Evans, JC},
   journal = {Cardiovasc Risk Factors},
   volume  = {2},
@@ -631,14 +833,15 @@
 }
 
 @article{kannel1992white,
-  title     = {White blood cell count and cardiovascular disease: insights from the Framingham Study},
+  title     = {White blood cell count and cardiovascular disease: insights from the {Framingham Study}},
   author    = {Kannel, William B and Anderson, Keaven and Wilson, Peter WF},
   journal   = {JAMA},
   volume    = {267},
   number    = {9},
   pages     = {1253--1256},
   year      = {1992},
-  publisher = {American Medical Association}
+  publisher = {American Medical Association},
+  doi       = {10.1001/jama.1992.03480090101035}
 }
 
 @article{kaufman1990reliably,
@@ -652,7 +855,7 @@
   publisher = {American Medical Association}
 }
 
-@article{kereiakes1998abciximab,
+@article{kereiakes1998abciximab1,
   title     = {Abciximab therapy and unplanned coronary stent deployment: favorable effects on stent use, clinical outcomes, and bleeding complications},
   author    = {Kereiakes, Dean J and Lincoff, A Michael and Miller, Dave P and Tcheng, James E and Cabot, Catherine F and Anderson, Keaven M and Weisman, Harlan F and Califf, Robert M and Topol, Eric J},
   journal   = {Circulation},
@@ -661,6 +864,16 @@
   pages     = {857--864},
   year      = {1998},
   publisher = {Am Heart Assoc}
+}
+
+@article{kereiakes1998abciximab2,
+  title     = {Abciximab associated thrombocytopenia: evidence for a complex interaction with heparin},
+  author    = {Kereiakes, DJ and Berkowitz, SD and Anderson, K and Simoons, M and Vahanian, A and Lincoff, AM and Tcheng, JE and Weisman, H and Califf, RM and Topol, EJ},
+  journal   = {Journal of the American College of Cardiology},
+  volume    = {31},
+  pages     = {55--55},
+  year      = {1998},
+  publisher = {American College of Cardiology Foundation Washington, DC}
 }
 
 @article{kereiakes2000clinical,
@@ -674,6 +887,17 @@
   publisher = {Elsevier}
 }
 
+@inproceedings{kereiakes2001abciximab,
+  title        = {Abciximab survival advantage is not explained by reduction in early major cardiac events: {EPIC}, {EPILOG} and {EPISTENT} 3 year analysis},
+  author       = {Kereiakes, DJ and Anderson, KM and Achenbach, RE and Melsheimer, RM and Kurz, MA and Barnathan, E},
+  booktitle    = {Circulation},
+  volume       = {104},
+  number       = {17},
+  pages        = {87--88},
+  year         = {2001},
+  organization = {LIPPINCOTT WILLIAMS \& WILKINS 530 WALNUT ST, PHILADELPHIA, PA 19106-3621 USA}
+}
+
 @article{kereiakes2002abciximab,
   title     = {Abciximab survival advantage following percutaneous coronary intervention is predicted by clinical risk profile},
   author    = {Kereiakes, Dean J and Lincoff, A Michael and Anderson, Keaven M and Achenbach, Robert and Patel, Kamlesh and Barnathan, Elliot and Califf, Robert M and Topol, Eric J},
@@ -682,7 +906,8 @@
   number    = {6},
   pages     = {628--630},
   year      = {2002},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/s0002-9149(02)02568-7}
 }
 
 @article{kleiman1998diabetes,
@@ -707,7 +932,7 @@
 }
 
 @article{kreger1989prevalence,
-  title     = {Prevalence of intraventricular block in the general population: the Framingham Study},
+  title     = {Prevalence of intraventricular block in the general population: the {Framingham Study}},
   author    = {Kreger, Bernard E and Anderson, Keaven M and Kannel, William B},
   journal   = {American Heart Journal},
   volume    = {117},
@@ -718,7 +943,7 @@
 }
 
 @article{kreger1991qrs,
-  title     = {{QRS} interval fails to predict coronary disease incidence: the Framingham Study},
+  title     = {{QRS} interval fails to predict coronary disease incidence: the {Framingham Study}},
   author    = {Kreger, Bernard E and Anderson, Keaven M and Levy, Daniel},
   journal   = {Archives of Internal Medicine},
   volume    = {151},
@@ -729,7 +954,7 @@
 }
 
 @article{kreger1992serum,
-  title     = {Serum cholesterol level, body mass index, and the risk of colon cancer. The Framingham Study},
+  title     = {Serum cholesterol level, body mass index, and the risk of colon cancer. {The Framingham Study}},
   author    = {Kreger, Bernard E and Anderson, Keaven M and Schatzkin, Arthur and Splansky, Greta Lee},
   journal   = {Cancer},
   volume    = {70},
@@ -740,7 +965,7 @@
 }
 
 @article{lauer1991impact,
-  title     = {The impact of obesity on left ventricular mass and geometry: the Framingham Heart Study},
+  title     = {The impact of obesity on left ventricular mass and geometry: the {Framingham Heart Study}},
   author    = {Lauer, Michael S and Anderson, Keaven M and Kannel, William B and Levy, Daniel},
   journal   = {JAMA},
   volume    = {266},
@@ -751,7 +976,7 @@
 }
 
 @article{lauer1991influence,
-  title     = {Influence of contemporary versus 30-year blood pressure levels on left ventricular mass and geometry: the Framingham Heart Study},
+  title     = {Influence of contemporary versus 30-year blood pressure levels on left ventricular mass and geometry: the {Framingham Heart Study}},
   author    = {Lauer, Michael S and Anderson, Keaven M and Levy, Daniel},
   journal   = {Journal of the American College of Cardiology},
   volume    = {18},
@@ -762,7 +987,7 @@
 }
 
 @article{lauer1992separate,
-  title     = {Separate and joint influences of obesity and mild hypertension on left ventricular mass and geometry: the Framingham Heart Study},
+  title     = {Separate and joint influences of obesity and mild hypertension on left ventricular mass and geometry: the {Framingham Heart Study}},
   author    = {Lauer, Michael S and Anderson, Keaven M and Levy, Daniel},
   journal   = {Journal of the American College of Cardiology},
   volume    = {19},
@@ -773,7 +998,7 @@
 }
 
 @article{lauer1992there,
-  title     = {Is there a relationship between exercise systolic blood pressure response and left ventricular mass? The Framingham Heart Study},
+  title     = {Is there a relationship between exercise systolic blood pressure response and left ventricular mass? {The Framingham Heart Study}},
   author    = {Lauer, Michael S and Levy, Daniel and Anderson, Keaven M and Plehn, Jonathan F},
   journal   = {Annals of Internal Medicine},
   volume    = {116},
@@ -827,6 +1052,17 @@
   organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
 }
 
+@inproceedings{lefkovits1995can,
+  title        = {Can conjunctive platelet glycoprotein {IIb}/{IIIa} receptor blockade improve outcomes of coronary interventions for restenotic lesions},
+  author       = {Lefkovits, J and Stoner, GL and Anderson, KM and Weisman, HF and Topol, EJ},
+  booktitle    = {Circulation},
+  volume       = {92},
+  number       = {8},
+  pages        = {2907--2907},
+  year         = {1995},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
 @article{lefkovits1996effects,
   title     = {Effects of platelet glycoprotein {IIb}/{IIIa} receptor blockade by a chimeric monoclonal antibody (abciximab) on acute and six-month outcomes after percutaneous transluminal coronary angioplasty for acute myocardial infarction},
   author    = {Lefkovits, Jeffrey and Ivanhoe, Russell J and Califf, Robert M and Bergelson, Bruce A and Anderson, Keaven M and Stoner, Gail L and Weisman, Harlan F and Topol, Eric J and Group EPIC Investigators and others},
@@ -838,8 +1074,31 @@
   publisher = {Elsevier}
 }
 
+@article{lefkovlts1995711,
+  title     = {711-5 Mechanism of Benefit of Platelet {IIb}/{IIIa} Receptor Inhibition in High Risk Angioplasty in the {EPIC} Trial: A Hierarchical Endpoint Analysis},
+  author    = {Lefkovlts, Jeffrey and Anderson, Keaven and Weisman, Harlan and Topol, Eric J and EPIC Investigators and others},
+  journal   = {Journal of the American College of Cardiology},
+  volume    = {25},
+  number    = {2},
+  pages     = {81A},
+  year      = {1995},
+  publisher = {Elsevier}
+}
+
+@article{leon2020weighted,
+  title     = {On weighted log-rank combination tests and companion {Cox} model estimators},
+  author    = {Le{\'o}n, Larry F and Lin, Ray and Anderson, Keaven M},
+  journal   = {Statistics in Biosciences},
+  volume    = {12},
+  number    = {2},
+  pages     = {225--245},
+  year      = {2020},
+  publisher = {Springer},
+  doi       = {10.1007/s12561-020-09276-1}
+}
+
 @inproceedings{levy1985association,
-  title        = {The association of left-ventricular hypertrophy with ventricular arrhythmias—the Framingham Heart Study},
+  title        = {The association of left-ventricular hypertrophy with ventricular arrhythmias---the {Framingham Heart Study}},
   author       = {Levy, D and Savage, DD and Garrison, RJ and Balkus, SA and Anderson, KM and Kannel, WB and Castelli, WP},
   booktitle    = {Circulation},
   volume       = {72},
@@ -849,8 +1108,19 @@
   organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
 }
 
+@inproceedings{levy1986prevalence,
+  title        = {Prevalence of ventricular arrhythmias in hypertensives treated with b-blockers or diuretics---the {Framingham Heart Study}},
+  author       = {Levy, D and Anderson, KM and Christiansen, J and STOKES, J},
+  booktitle    = {Circulation},
+  volume       = {74},
+  number       = {4},
+  pages        = {489--489},
+  year         = {1986},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
 @article{levy1987echocardiographic,
-  title     = {Echocardiographic criteria for left ventricular hypertrophy: the Framingham Heart Study},
+  title     = {Echocardiographic criteria for left ventricular hypertrophy: the {Framingham Heart Study}},
   author    = {Levy, Daniel and Savage, Daniel D and Garrison, Robert J and Anderson, Keaven M and Kannel, William B and Castelli, William P},
   journal   = {The American Journal of Cardiology},
   volume    = {59},
@@ -872,7 +1142,7 @@
 }
 
 @inproceedings{levy1987influence,
-  title        = {Influence of 30 year mean blood-pressure levels on left-ventricular mass—the Framingham Heart Study},
+  title        = {Influence of 30 year mean blood-pressure levels on left-ventricular mass---the {Framingham Heart Study}},
   author       = {Levy, D and Anderson, K and Savage, DD and Kannel, WB and Castelli, WP},
   booktitle    = {Journal of the American College of Cardiology},
   volume       = {9},
@@ -883,7 +1153,7 @@
 }
 
 @article{levy1987risk,
-  title     = {Risk of ventricular arrhythmias in left ventricular hypertrophy: the Framingham Heart Study},
+  title     = {Risk of ventricular arrhythmias in left ventricular hypertrophy: the {Framingham Heart Study}},
   author    = {Levy, Daniel and Anderson, Keaven M and Savage, Daniel D and Balkus, Susan A and Kannel, William B and Castelli, William P},
   journal   = {The American Journal of Cardiology},
   volume    = {60},
@@ -905,7 +1175,7 @@
 }
 
 @article{levy1988echocardiographically,
-  title     = {Echocardiographically detected left ventricular hypertrophy: prevalence and risk factors: the Framingham Heart Study},
+  title     = {Echocardiographically detected left ventricular hypertrophy: prevalence and risk factors: the {Framingham Heart Study}},
   author    = {Levy, Daniel and Anderson, Keaven M and Savage, Daniel D and Kannel, William B and Christiansen, Jane C and Castelli, William P},
   journal   = {Annals of internal medicine},
   volume    = {108},
@@ -927,18 +1197,19 @@
 }
 
 @article{levy1990prognostic,
-  title     = {Prognostic implications of echocardiographically determined left ventricular mass in the Framingham Heart Study},
+  title     = {Prognostic implications of echocardiographically determined left ventricular mass in the {Framingham Heart Study}},
   author    = {Levy, Daniel and Garrison, Robert J and Savage, Daniel D and Kannel, William B and Castelli, William P},
   journal   = {New England Journal of Medicine},
   volume    = {322},
   number    = {22},
   pages     = {1561--1566},
   year      = {1990},
-  publisher = {Mass Medical Soc}
+  publisher = {Mass Medical Soc},
+  doi       = {10.1056/NEJM199005313222203}
 }
 
 @article{levy1990stratifying,
-  title     = {Stratifying the patient at risk from coronary disease: new insights from the Framingham Heart Study},
+  title     = {Stratifying the patient at risk from coronary disease: new insights from the {Framingham Heart Study}},
   author    = {Levy, Daniel and Wilson, Peter WF and Anderson, Keaven M and Castelli, William P},
   journal   = {American Heart Journal},
   volume    = {119},
@@ -949,7 +1220,7 @@
 }
 
 @article{levy1992echocardiographic,
-  title     = {Echocardiographic left ventricular hypertrophy: clinical characteristics. The Framingham Heart Study},
+  title     = {Echocardiographic left ventricular hypertrophy: clinical characteristics. {The Framingham Heart Study}},
   author    = {Levy, Daniel and Murabito, Joanne M and Anderson, Keaven M and Christiansen, Jane C and Castelli, William P},
   journal   = {Clinical and Experimental Hypertension. Part A: Theory and Practice},
   volume    = {14},
@@ -967,7 +1238,8 @@
   number    = {2},
   pages     = {187--198},
   year      = {2020},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/19466315.2019.1697738}
 }
 
 @article{lin2020rejoinder,
@@ -978,7 +1250,8 @@
   number    = {4},
   pages     = {520},
   year      = {2020},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/19466315.2020.1825522}
 }
 
 @inproceedings{lincoff1997abciximab,
@@ -990,6 +1263,17 @@
   pages        = {7396--7396},
   year         = {1997},
   organization = {ELSEVIER SCIENCE INC 655 AVENUE OF THE AMERICAS, NEW YORK, NY 10010}
+}
+
+@inproceedings{lincoff1997durable,
+  title        = {Durable inhibition of ischemic complications by abciximab during percutaneous coronary revascularization: one-year results of the {EPILOG} trial},
+  author       = {Lincoff, AM and Tcheng, JE and Anderson, KM and Cabot, CF},
+  booktitle    = {Circulation},
+  volume       = {96},
+  number       = {8},
+  pages        = {902--902},
+  year         = {1997},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
 }
 
 @inproceedings{lincoff1997economic,
@@ -1005,7 +1289,7 @@
 
 @article{lincoff1997evidence,
   title     = {Evidence for prevention of death and myocardial infarction with platelet membrane glycoprotein {IIb}/{IIIa} receptor blockade by abciximab ({c7E3 Fab}) among patients with unstable angina undergoing percutaneous coronary revascularization},
-  author    = {Lincoff, A Michael and Califf, Robert M and Anderson, Keaven M and Weisman, Harlan F and Aguirre, Frank V and Kleiman, Neal S and Harrington, Robert A and Topol, Eric J and EPIC investigators},
+  author    = {Lincoff, A Michael and Califf, Robert M and Anderson, Keaven M and Weisman, Harlan F and Aguirre, Frank V and Kleiman, Neal S and Harrington, Robert A and Topol, Eric J and {EPIC} investigators},
   journal   = {Journal of the American College of Cardiology},
   volume    = {30},
   number    = {1},
@@ -1048,14 +1332,15 @@
 }
 
 @article{liu2004benefit,
-  title     = {Benefit--risk evaluation of multi-stage adaptive designs},
+  title     = {Benefit-risk evaluation of multi-stage adaptive designs},
   author    = {Liu, Qing and Anderson, Keaven M and Pledger, Gordon W},
   journal   = {Sequential Analysis},
   volume    = {23},
   number    = {3},
   pages     = {317--331},
   year      = {2004},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1081/SQA-200027049}
 }
 
 @article{liu2008adaptive,
@@ -1066,14 +1351,16 @@
   number    = {484},
   pages     = {1621--1630},
   year      = {2008},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1198/016214508000000986}
 }
 
 @article{liu2008theory,
   title   = {Theory of inference for adaptively extended group sequential designs with applications in clinical trials},
   author  = {Liu, Q and Anderson, KM},
   journal = {Journal of the American Statistical Association, Supplemental Archive},
-  year    = {2008}
+  year    = {2008},
+  url     = {https://www.tandfonline.com/doi/suppl/10.1198/016214508000000986}
 }
 
 @article{liu2012efficient,
@@ -1084,7 +1371,8 @@
   number    = {4},
   pages     = {617--640},
   year      = {2012},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/10543406.2012.678226}
 }
 
 @article{mak1997effect,
@@ -1109,6 +1397,36 @@
   publisher = {Am Heart Assoc}
 }
 
+@article{mauskopf1999tpct2,
+  title   = {TPCT2: Cost-effectiveness of abciximab in percutaneous coronary intervention patients: results from a meta-analysis},
+  author  = {Mauskopf, JA and Bala, MV and Hermiller, JB and Barber, BL and Anderson, KM},
+  journal = {Value in Health},
+  volume  = {3},
+  number  = {2},
+  pages   = {153},
+  year    = {1999}
+}
+
+@inproceedings{moliterno1994activated,
+  title        = {Activated clotting time is increased during coronary interventions with platelet IIb/IIIa antagonism-results from the {EPIC} trial},
+  author       = {Moliterno, DJ and Califf, RM and Anderson, K and Sigmon, KN and Aguirre, F and Weisman, HF and Topol, EJ},
+  booktitle    = {Journal of the American College of Cardiology},
+  pages        = {A106--A106},
+  year         = {1994},
+  organization = {ELSEVIER SCIENCE INC 655 AVENUE OF THE AMERICAS, NEW YORK, NY 10010}
+}
+
+@article{moliterno1995935,
+  title     = {935-34 Special Considerations for Diabetics Receiving Platelet {IIb}/{IIIa} Antagonists During Coronary Interventions: Results from the {EPIC} Trialart},
+  author    = {Moliterno, David J and Califf, Robert M and Anderson, Keavin and Weisman, Harlan F and Topol, Eric J},
+  journal   = {Journal of the American College of Cardiology},
+  volume    = {25},
+  number    = {2},
+  pages     = {155A--156A},
+  year      = {1995},
+  publisher = {Elsevier}
+}
+
 @article{moliterno1995effect,
   title     = {Effect of platelet glycoprotein {IIb}/{IIIa} integrin blockade on activated clotting time during percutaneous transluminal coronary angioplasty or directional atherectomy (the {EPIC} trial)},
   author    = {Moliterno, David J and Califf, Robert M and Aguirre, Frank V and Anderson, Keaven and Sigmon, Kristina N and Weisman, Harlan F and Topol, Eric J and {EPIC Study Investigators} and others},
@@ -1120,8 +1438,16 @@
   publisher = {Elsevier}
 }
 
+@article{mukhopadhyay2022log,
+  title   = {Log-Rank Test vs MaxCombo and Difference in Restricted Mean Survival Time Tests for Comparing Survival Under Nonproportional Hazards in Immuno-oncology Trials: A Systematic Review and Meta-analysis},
+  author  = {Mukhopadhyay, Pralay and Ye, Jiabu and Anderson, Keaven M and Roychoudhury, Satrajit and Rubin, Eric H and Halabi, Susan and Chappell, Richard J},
+  journal = {JAMA Oncology},
+  year    = {2022},
+  doi     = {10.1001/jamaoncol.2022.2666}
+}
+
 @article{murabito1990risk,
-  title     = {Risk of coronary heart disease in subjects with chest discomfort: the Framingham Heart Study},
+  title     = {Risk of coronary heart disease in subjects with chest discomfort: the {Framingham Heart Study}},
   author    = {Murabito, Joanne M and Anderson, Keaven M and Kannel, William B and Evans, Jane C and Levy, Daniel},
   journal   = {The American Journal of Medicine},
   volume    = {89},
@@ -1132,7 +1458,7 @@
 }
 
 @article{o1987prevalence,
-  title   = {Prevalence and prognosis of dyspnea in the Framingham Study},
+  title   = {Prevalence and prognosis of dyspnea in the {Framingham Study}},
   author  = {O'Connor, GT and Anderson, KM and Kannel, WB and Brand, FN and Christiansen, JC and Weiss, ST and Speizer, FE},
   journal = {Chest},
   volume  = {92},
@@ -1142,7 +1468,7 @@
 }
 
 @article{o1992cholesterol,
-  title     = {Cholesterol and carotid atherosclerosis in older persons: the Framingham Study},
+  title     = {Cholesterol and carotid atherosclerosis in older persons: the {Framingham Study}},
   author    = {O'Leary, Daniel H and Anderson, Keaven M and Wolf, Philip A and Evans, Jane C and Poehlman, Harold W},
   journal   = {Annals of Epidemiology},
   volume    = {2},
@@ -1173,7 +1499,7 @@
 }
 
 @article{okin1991heart,
-  title     = {Heart rate adjustment of exercise-induced {ST} segment depression. Improved risk stratification in the Framingham Offspring Study.},
+  title     = {Heart rate adjustment of exercise-induced {ST} segment depression. Improved risk stratification in the {Framingham Offspring Study}},
   author    = {Okin, Peter M and Anderson, KM and Levy, D and Kligfield, P},
   journal   = {Circulation},
   volume    = {83},
@@ -1184,7 +1510,7 @@
 }
 
 @inproceedings{oleary1988extracranial,
-  title        = {Extracranial carotid atherosclerosis in a general population—the Framingham Study},
+  title        = {Extracranial carotid atherosclerosis in a general population---the {Framingham Study}},
   author       = {OLEARY, DH and Anderson, KM and Kase, CS and Wolf, PA and Kannel, WB},
   booktitle    = {Stroke},
   volume       = {19},
@@ -1222,7 +1548,20 @@
   journal   = {Statistics in Biopharmaceutical Research},
   pages     = {1--15},
   year      = {2021},
-  publisher = {Taylor \& Francis}
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/19466315.2021.1874507}
+}
+
+@article{rubin2010finding,
+  title     = {Finding the Right Dose for Cancer Therapeutics—Can We Do Better?},
+  author    = {Rubin, Eric H and Anderson, Keaven M},
+  journal   = {Clinical Cancer Research},
+  volume    = {16},
+  number    = {4},
+  pages     = {1085--1087},
+  year      = {2010},
+  publisher = {AACR},
+  doi       = {10.1158/1078-0432.CCR-09-3246}
 }
 
 @article{rubin2011battle,
@@ -1233,11 +1572,12 @@
   number    = {1},
   pages     = {17--20},
   year      = {2011},
-  publisher = {AACR}
+  publisher = {AACR},
+  doi       = {10.1158/2159-8274.CD-11-0036}
 }
 
 @article{schatzkin1989alcohol,
-  title     = {Is alcohol consumption related to breast cancer? Results from the Framingham Heart Study},
+  title     = {Is alcohol consumption related to breast cancer? Results from the {Framingham Heart Study}},
   author    = {Schatzkin, Arthur and Carter, Christine L and Green, Sylvan B and Kreger, Bernard E and Splansky, Greta L and Anderson, Keaven M and Helsel, surname and Kannel, William B},
   journal   = {JNCI: Journal of the National Cancer Institute},
   volume    = {81},
@@ -1268,8 +1608,30 @@
   year    = {1991}
 }
 
+@inproceedings{simoons1997small,
+  title        = {Small, non-{Q} wave myocardial infarctions during {PTCA}, are associated with increased 6 months mortality},
+  author       = {Simoons, ML and Harrington, RA and Anderson, KM and Deckers, JW and VanPapendrecht, MH},
+  booktitle    = {Circulation},
+  volume       = {96},
+  number       = {8},
+  pages        = {163--163},
+  year         = {1997},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
+@inproceedings{singer1988glycated,
+  title        = {Glycated hemoglobin is associated with cardiovascular-disease in females of the {Framingham} cohort, even among non-diabetics},
+  author       = {Singer, DE and Nathan, DM and Wilson, PWF and Anderson, KM},
+  booktitle    = {Clinical Research},
+  volume       = {36},
+  number       = {3},
+  pages        = {A350--A350},
+  year         = {1988},
+  organization = {SLACK INC 6900 GROVE RD, THOROFARE, NJ 08086}
+}
+
 @article{singer1992association,
-  title     = {Association of ${HbA}_{1c}$ with prevalent cardiovascular disease in the original cohort of the Framingham Heart Study},
+  title     = {Association of ${HbA}_{1c}$ with prevalent cardiovascular disease in the original cohort of the {Framingham Heart Study}},
   author    = {Singer, Daniel E and Nathan, David M and Anderson, Keaven M and Wilson, Peter WF and Evans, Jane C},
   journal   = {Diabetes},
   volume    = {41},
@@ -1289,6 +1651,61 @@
   year    = {1985}
 }
 
+@article{sobol1986reproducibility,
+  title     = {The reproducibility of acute lymphoblastic leukemia phenotype determinations: Evaluation of monoclonal antibody and conventional hematopoietic markers},
+  author    = {Sobol, Robert E and Mick, Rosemarie and Lebien, Tucker W and Ozer, Howard and Minowada, Jun and Anderson, Keaven and Ellison, Rose Ruth and Cuttner, Janet and Morrison, Alan and Richards II, Frederick and others},
+  journal   = {Leukemia research},
+  volume    = {10},
+  number    = {5},
+  pages     = {481--485},
+  year      = {1986},
+  publisher = {Elsevier}
+}
+
+@inproceedings{sutton1993body,
+  title        = {Body-weight and heparin dosing influence bleeding complications with {c7E3} antiplatelet antibody},
+  author       = {Sutton, JM and Anderson, K},
+  booktitle    = {Circulation},
+  volume       = {88},
+  number       = {4},
+  pages        = {209--209},
+  year         = {1993},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
+@inproceedings{tardiff1997reduced,
+  title        = {Reduced need for coronary bypass surgery ({CABG}) after percutaneous intervention in patients treated with abciximab},
+  author       = {Tardiff, BE and Anderson, KM and Cabot, CF and Deckers, JW and Simoons, ML},
+  booktitle    = {Circulation},
+  volume       = {96},
+  number       = {8},
+  pages        = {931--931},
+  year         = {1997},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
+@inproceedings{tcheng1993improvement,
+  title        = {Improvement in clinical outcomes of coronary angioplasty by treatment with the {GPIIb}/{IIIa} inhibitor chimeric-7e3-multivariable analysis of the {EPIC} study},
+  author       = {Tcheng, JE and Topol, EJ and Kleiman, NS and Ellis, SG and Navetta, FI and Fintel, DJ and Weisman, HF and Anderson, K and Wang, AL and Miller, JA and others},
+  booktitle    = {Circulation},
+  volume       = {88},
+  number       = {4},
+  pages        = {506--506},
+  year         = {1993},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
+@inproceedings{tcheng1997reducing,
+  title        = {Reducing the risk of percutaneous intervention after coronary bypass surgery: Beneficial effects of abciximab treatment},
+  author       = {Tcheng, JE and Anderson, K and Tardiff, BE and Cabot, CF and Lincoff, AM and Califf, RM and Topol, EJ},
+  booktitle    = {Journals of the American College of Cardiology},
+  volume       = {29},
+  number       = {2},
+  pages        = {7395--7395},
+  year         = {1997},
+  organization = {ELSEVIER SCIENCE INC 655 AVENUE OF THE AMERICAS, NEW YORK, NY 10010}
+}
+
 @article{tian2020empirical,
   title     = {On the empirical choice of the time window for restricted mean survival time},
   author    = {Tian, Lu and Jin, Hua and Uno, Hajime and Lu, Ying and Huang, Bo and Anderson, Keaven M and Wei, LJ},
@@ -1297,7 +1714,17 @@
   number    = {4},
   pages     = {1157--1166},
   year      = {2020},
-  publisher = {Wiley Online Library}
+  publisher = {Wiley Online Library},
+  doi       = {10.1111/biom.13237}
+}
+
+@inproceedings{topol19946,
+  title        = {6-month follow-up after acute-phase platelet {IIb}/{IIIa} integrin blockade in the epic trial-reduction in need for revascularization procedures},
+  author       = {Topol, EJ and Califf, RM and Weisman, HF and Anderson, K and Wang, A and Willerson, JT},
+  booktitle    = {Journal of the American College of Cardiology},
+  pages        = {A60--A60},
+  year         = {1994},
+  organization = {ELSEVIER SCIENCE INC 655 AVENUE OF THE AMERICAS, NEW YORK, NY 10010}
 }
 
 @article{topol1994randomised,
@@ -1308,7 +1735,8 @@
   number    = {8902},
   pages     = {881--886},
   year      = {1994},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/S0140-6736(94)90007-8}
 }
 
 @article{topol1997long,
@@ -1319,7 +1747,8 @@
   number    = {6},
   pages     = {479--484},
   year      = {1997},
-  publisher = {American Medical Association}
+  publisher = {American Medical Association},
+  doi       = {10.1001/jama.1997.03550060055036}
 }
 
 @article{topol1999outcomes,
@@ -1330,18 +1759,32 @@
   number    = {9195},
   pages     = {2019--2024},
   year      = {1999},
-  publisher = {Elsevier}
+  publisher = {Elsevier},
+  doi       = {10.1016/s0140-6736(99)10018-7}
 }
 
 @article{turner2018pembrolizumab,
-  title     = {Pembrolizumab Exposure--Response Assessments Challenged by Association of Cancer Cachexia and Catabolic ClearancePembrolizumab PK/PD Confounding and Cancer Cachexia},
+  title     = {Pembrolizumab Exposure-Response Assessments Challenged by Association of Cancer Cachexia and Catabolic Clearance},
   author    = {Turner, David C and Kondic, Anna G and Anderson, Keaven M and Robinson, Andrew G and Garon, Edward B and Riess, Jonathan Wesley and Jain, Lokesh and Mayawala, Kapil and Kang, Jiannan and Ebbinghaus, Scot W and others},
   journal   = {Clinical Cancer Research},
   volume    = {24},
   number    = {23},
   pages     = {5841--5849},
   year      = {2018},
-  publisher = {AACR}
+  publisher = {AACR},
+  doi       = {10.1158/1078-0432.CCR-18-0415}
+}
+
+@article{wan2015stepwise,
+  title     = {Stepwise two-stage sample size adaptation},
+  author    = {Wan, Hong and Ellenberg, Susan S and Anderson, Keaven M},
+  journal   = {Statistics in Medicine},
+  volume    = {34},
+  number    = {1},
+  pages     = {27--38},
+  year      = {2015},
+  publisher = {Wiley Online Library},
+  doi       = {10.1002/sim.6311}
 }
 
 @article{weisman1995anti,
@@ -1361,7 +1804,8 @@
   journal   = {Biometrics},
   pages     = {899--905},
   year      = {1982},
-  publisher = {JSTOR}
+  publisher = {JSTOR},
+  doi       = {10.2307/2529870}
 }
 
 @article{whittemore1983early,
@@ -1398,7 +1842,7 @@
 }
 
 @article{wilson1985lipids,
-  title   = {Lipids, glucose intolerance and vascular disease: the Framingham Study},
+  title   = {Lipids, glucose intolerance and vascular disease: the {Framingham Study}},
   author  = {Wilson, PW and Kannel, WB and Anderson, KM},
   journal = {Monographs on Atherosclerosis},
   volume  = {13},
@@ -1407,7 +1851,7 @@
 }
 
 @article{wilson1986epidemiology,
-  title     = {Epidemiology of diabetes mellitus in the elderly: the Framingham Study},
+  title     = {Epidemiology of diabetes mellitus in the elderly: the {Framingham Study}},
   author    = {Wilson, Peter WF and Anderson, Keaven M and Kannel, William B},
   journal   = {The American Journal of Medicine},
   volume    = {80},
@@ -1418,7 +1862,7 @@
 }
 
 @article{wilson1989impact,
-  title     = {Impact of national guidelines for cholesterol risk factor screening: the Framingham Offspring Study},
+  title     = {Impact of national guidelines for cholesterol risk factor screening: the {Framingham Offspring Study}},
   author    = {Wilson, Peter WF and Christiansen, Jane C and Anderson, Keaven M and Kannel, William B},
   journal   = {JAMA},
   volume    = {262},
@@ -1428,8 +1872,28 @@
   publisher = {American Medical Association}
 }
 
+@inproceedings{wilson1990cholesterol,
+  title        = {Cholesterol and {CHD} in the elderly---the {Framingham} cohort},
+  author       = {Wilson, PWF and Kannel, WB and Anderson, KM and Castelli, WP},
+  booktitle    = {Circulation},
+  volume       = {82},
+  number       = {4},
+  pages        = {576--576},
+  year         = {1990},
+  organization = {AMER HEART ASSOC 7272 GREENVILLE AVENUE, DALLAS, TX 75231-4596}
+}
+
+@incollection{wilson1990hdl,
+  title     = {{HDL} cholesterol and triglycerides as risk factors for {CHD}},
+  author    = {Wilson, PWF and Anderson, KM},
+  booktitle = {Atherosclerosis and cardiovascular disease},
+  pages     = {609--615},
+  year      = {1990},
+  publisher = {Springer}
+}
+
 @article{wilson1991impact,
-  title   = {The impact of triglycerides on coronary heart disease: the Framingham Study},
+  title   = {The impact of triglycerides on coronary heart disease: the {Framingham Study}},
   author  = {Wilson, Peter WF and Anderson, Keaven M and Castelli, WP},
   journal = {Athero Rev},
   volume  = {22},
@@ -1438,7 +1902,7 @@
 }
 
 @article{wilson1991twelve,
-  title     = {Twelve-year incidence of coronary heart disease in middle-aged adults during the era of hypertensive therapy: the Framingham Offspring Study},
+  title     = {Twelve-year incidence of coronary heart disease in middle-aged adults during the era of hypertensive therapy: the {Framingham Offspring Study}},
   author    = {Wilson, Peter WF and Anderson, Keaven M and Castelli, William P and Kannel, William B},
   journal   = {The American Journal of Medicine},
   volume    = {90},
@@ -1449,7 +1913,7 @@
 }
 
 @article{wilson1994determinants,
-  title     = {Determinants of change in total cholesterol and {HDL-C} with age: the Framingham Study},
+  title     = {Determinants of change in total cholesterol and {HDL-C} with age: the {Framingham Study}},
   author    = {Wilson, Peter WF and Anderson, Keaven M and Harri, Tamara and Kannel, William B and Castelli, William P},
   journal   = {Journal of Gerontology},
   volume    = {49},
@@ -1457,4 +1921,16 @@
   pages     = {M252--M257},
   year      = {1994},
   publisher = {The Gerontological Society of America}
+}
+
+@article{zhou2014information,
+  title     = {Information-based sample size re-estimation in group sequential design for longitudinal trials},
+  author    = {Zhou, Jing and Adewale, Adeniyi and Shentu, Yue and Liu, Jiajun and Anderson, Keaven},
+  journal   = {Statistics in Medicine},
+  volume    = {33},
+  number    = {22},
+  pages     = {3801--3814},
+  year      = {2014},
+  publisher = {Wiley Online Library},
+  doi       = {10.1002/sim.6192}
 }

--- a/content/publications.Rmd
+++ b/content/publications.Rmd
@@ -4,35 +4,9 @@ title: Publications
 
 <!-- After the .bib file is updated, knit this Rmd to update publications.html, then commit and push both the .bib and .html -->
 
-(Under construction)
-
 [Google Scholar curated citations](https://scholar.google.com/citations?user=P5Rt1VEAAAAJ&hl=en)
 
-## Recent
-
-Mukhopadhyay, P., Ye, J., Anderson, K. M., Roychoudhury, S., Rubin, E. H., Halabi, S., & Chappell, R. J. (2022). Log-Rank Test vs MaxCombo and Difference in Restricted Mean Survival Time Tests for Comparing Survival Under Nonproportional Hazards in Immuno-oncology Trials: A Systematic Review and Meta-analysis. JAMA oncology.
-
-Anderson, K. M., Guo, Z., Zhao, J., & Sun, L. Z. (2022). A unified framework for weighted parametric group sequential design. Biometrical Journal.
-
-Chen, T. Y., Zhao, J., Sun, L., & Anderson, K. M. (2021). Multiplicity for a group sequential trial with biomarker subpopulations. Contemporary Clinical Trials, 101, 106249.
-
-Bautista, O., & Anderson, K. (2021). Sample Size Estimation and Power Analysis: Time to Event Data. In Handbook of Statistical Methods for Randomized Controlled Trials (pp. 275-300). Chapman and Hall/CRC.
-
-Roychoudhury, S., Anderson, K. M., Ye, J., & Mukhopadhyay, P. (2021). Robust design and analysis of clinical trials with nonproportional hazards: a straw man guidance from a cross-pharma working group. Statistics in Biopharmaceutical Research, 1-15.
-
-Lin, R. S., Lin, J., Roychoudhury, S., Anderson, K. M., Hu, T., Huang, B., ... & Working, C. P. N. P. H. (2020). Rejoinder to letter to the editor “The hazards of period specific and weighted hazard ratios”. Statistics in Biopharmaceutical Research, 12(4), 520.
-
-Lin, R. S., Lin, J., Roychoudhury, S., Anderson, K. M., Hu, T., Huang, B., ... & Cross-Pharma Non-Proportional Hazards Working Group. (2020). Alternative analysis methods for time to event endpoints under nonproportional hazards: a comparative analysis. Statistics in Biopharmaceutical Research, 12(2), 187-198.
-
-Tian, L., Jin, H., Uno, H., Lu, Y., Huang, B., Anderson, K. M., & Wei, L. J. (2020). On the empirical choice of the time window for restricted mean survival time. Biometrics, 76(4), 1157-1166.
-
-León, L. F., Lin, R., & Anderson, K. M. (2020). On weighted log-rank combination tests and companion Cox model estimators. Statistics in Biosciences, 12(2), 225-245.
-
-Turner, D. C., Kondic, A. G., Anderson, K. M., Robinson, A. G., Garon, E. B., Riess, J. W., ... & Stone, J. A. (2018). Pembrolizumab Exposure–Response Assessments Challenged by Association of Cancer Cachexia and Catabolic ClearancePembrolizumab PK/PD Confounding and Cancer Cachexia. Clinical Cancer Research, 24(23), 5841-5849.
-
-Joseph, Richard W., et al. "Baseline Tumor Size Is an Independent Prognostic Factor for Overall Survival in Patients with Melanoma Treated with Pembrolizumab: Impact of Baseline Tumor Size on Outcomes in Melanoma." *Clinical Cancer Research* *24.20* (2018): 4960-4967.
-
-Chen, Cong, et al. "A 2-in-1 adaptive phase 2/3 design for expedited oncology drug development." Contemporary clinical trials 64 (2018): 238-242.
+[Download BibTeX file](https://keaven.github.io/keaven.bib)
 
 ```{r, include=FALSE}
 df <- bib2df::bib2df("keaven.bib") |> suppressWarnings()

--- a/content/publications.html
+++ b/content/publications.html
@@ -5,50 +5,65 @@ title: Publications
 
 
 <!-- After the .bib file is updated, knit this Rmd to update publications.html, then commit and push both the .bib and .html -->
-<p>(Under construction)</p>
-<div id="recent" class="section level2">
-<h2>Recent</h2>
-<p>Mukhopadhyay, P., Ye, J., Anderson, K. M., Roychoudhury, S., Rubin, E. H., Halabi, S., &amp; Chappell, R. J. (2022). Log-Rank Test vs MaxCombo and Difference in Restricted Mean Survival Time Tests for Comparing Survival Under Nonproportional Hazards in Immuno-oncology Trials: A Systematic Review and Meta-analysis. JAMA oncology.</p>
-<p>Anderson, K. M., Guo, Z., Zhao, J., &amp; Sun, L. Z. (2022). A unified framework for weighted parametric group sequential design. Biometrical Journal.</p>
-<p>Chen, T. Y., Zhao, J., Sun, L., &amp; Anderson, K. M. (2021). Multiplicity for a group sequential trial with biomarker subpopulations. Contemporary Clinical Trials, 101, 106249.</p>
-<p>Bautista, O., &amp; Anderson, K. (2021). Sample Size Estimation and Power Analysis: Time to Event Data. In Handbook of Statistical Methods for Randomized Controlled Trials (pp. 275-300). Chapman and Hall/CRC.</p>
-<p>Roychoudhury, S., Anderson, K. M., Ye, J., &amp; Mukhopadhyay, P. (2021). Robust design and analysis of clinical trials with nonproportional hazards: a straw man guidance from a cross-pharma working group. Statistics in Biopharmaceutical Research, 1-15.</p>
-<p>Lin, R. S., Lin, J., Roychoudhury, S., Anderson, K. M., Hu, T., Huang, B., … &amp; Working, C. P. N. P. H. (2020). Rejoinder to letter to the editor “The hazards of period specific and weighted hazard ratios”. Statistics in Biopharmaceutical Research, 12(4), 520.</p>
-<p>Lin, R. S., Lin, J., Roychoudhury, S., Anderson, K. M., Hu, T., Huang, B., … &amp; Cross-Pharma Non-Proportional Hazards Working Group. (2020). Alternative analysis methods for time to event endpoints under nonproportional hazards: a comparative analysis. Statistics in Biopharmaceutical Research, 12(2), 187-198.</p>
-<p>Tian, L., Jin, H., Uno, H., Lu, Y., Huang, B., Anderson, K. M., &amp; Wei, L. J. (2020). On the empirical choice of the time window for restricted mean survival time. Biometrics, 76(4), 1157-1166.</p>
-<p>León, L. F., Lin, R., &amp; Anderson, K. M. (2020). On weighted log-rank combination tests and companion Cox model estimators. Statistics in Biosciences, 12(2), 225-245.</p>
-<p>Turner, D. C., Kondic, A. G., Anderson, K. M., Robinson, A. G., Garon, E. B., Riess, J. W., … &amp; Stone, J. A. (2018). Pembrolizumab Exposure–Response Assessments Challenged by Association of Cancer Cachexia and Catabolic ClearancePembrolizumab PK/PD Confounding and Cancer Cachexia. Clinical Cancer Research, 24(23), 5841-5849.</p>
-<p>Joseph, Richard W., et al. “Baseline Tumor Size Is an Independent Prognostic Factor for Overall Survival in Patients with Melanoma Treated with Pembrolizumab: Impact of Baseline Tumor Size on Outcomes in Melanoma.” <em>Clinical Cancer Research</em> <em>24.20</em> (2018): 4960-4967.</p>
-<p>Chen, Cong, et al. “A 2-in-1 adaptive phase 2/3 design for expedited oncology drug development.” Contemporary clinical trials 64 (2018): 238-242.</p>
-</div>
+<p><a href="https://scholar.google.com/citations?user=P5Rt1VEAAAAJ&amp;hl=en">Google Scholar curated citations</a></p>
+<p><a href="https://keaven.github.io/keaven.bib">Download BibTeX file</a></p>
 <div id="section" class="section level2">
-<h2>2021</h2>
+<h2>2022</h2>
 <ul>
-<li>Roychoudhury, S., Anderson, K. M., Ye, J., &amp; Mukhopadhyay, P.
-(2021). Robust design and analysis of clinical trials with
-nonproportional hazards: A straw man guidance from a cross-pharma
-working group. <em>Statistics in Biopharmaceutical Research</em>, 1–15.</li>
+<li><p>Anderson, K. M., Guo, Z., Zhao, J., &amp; Sun, L. Z. (2022). A unified
+framework for weighted parametric group sequential design. <em>Biometrical
+Journal</em>. <a href="https://doi.org/10.1002/bimj.202100085" class="uri">https://doi.org/10.1002/bimj.202100085</a></p></li>
+<li><p>Mukhopadhyay, P., Ye, J., Anderson, K. M., Roychoudhury, S., Rubin,
+E. H., Halabi, S., &amp; Chappell, R. J. (2022). Log-rank test vs MaxCombo
+and difference in restricted mean survival time tests for comparing
+survival under nonproportional hazards in immuno-oncology trials: A
+systematic review and meta-analysis. <em>JAMA Oncology</em>.
+<a href="https://doi.org/10.1001/jamaoncol.2022.2666" class="uri">https://doi.org/10.1001/jamaoncol.2022.2666</a></p></li>
 </ul>
 </div>
 <div id="section-1" class="section level2">
+<h2>2021</h2>
+<ul>
+<li><p>Bautista, O., &amp; Anderson, K. (2021). Sample size estimation and
+power analysis: Time to event data. In <em>Handbook of statistical methods
+for randomized controlled trials</em> (pp. 275–300). Chapman; Hall/CRC.
+<a href="https://doi.org/10.1201/9781315119694" class="uri">https://doi.org/10.1201/9781315119694</a></p></li>
+<li><p>Chen, T.-Y., Zhao, J., Sun, L., &amp; Anderson, K. M. (2021).
+Multiplicity for a group sequential trial with biomarker subpopulations.
+<em>Contemporary Clinical Trials</em>, <em>101</em>, 106249.
+<a href="https://doi.org/10.1016/j.cct.2020.106249" class="uri">https://doi.org/10.1016/j.cct.2020.106249</a></p></li>
+<li><p>Roychoudhury, S., Anderson, K. M., Ye, J., &amp; Mukhopadhyay, P.
+(2021). Robust design and analysis of clinical trials with
+nonproportional hazards: A straw man guidance from a cross-pharma
+working group. <em>Statistics in Biopharmaceutical Research</em>, 1–15.
+<a href="https://doi.org/10.1080/19466315.2021.1874507" class="uri">https://doi.org/10.1080/19466315.2021.1874507</a></p></li>
+</ul>
+</div>
+<div id="section-2" class="section level2">
 <h2>2020</h2>
 <ul>
+<li><p>León, L. F., Lin, R., &amp; Anderson, K. M. (2020). On weighted log-rank
+combination tests and companion Cox model estimators. <em>Statistics in
+Biosciences</em>, <em>12</em>(2), 225–245.
+<a href="https://doi.org/10.1007/s12561-020-09276-1" class="uri">https://doi.org/10.1007/s12561-020-09276-1</a></p></li>
 <li><p>Lin, R. S., Lin, J., Roychoudhury, S., Anderson, K. M., Hu, T.,
 Huang, B., Leon, L. F., Liao, J. J., Liu, R., Luo, X., et al. (2020).
 Alternative analysis methods for time to event endpoints under
 nonproportional hazards: A comparative analysis. <em>Statistics in
-Biopharmaceutical Research</em>, <em>12</em>(2), 187–198.</p></li>
+Biopharmaceutical Research</em>, <em>12</em>(2), 187–198.
+<a href="https://doi.org/10.1080/19466315.2019.1697738" class="uri">https://doi.org/10.1080/19466315.2019.1697738</a></p></li>
 <li><p>Lin, R. S., Lin, J., Roychoudhury, S., Anderson, K. M., Hu, T.,
 Huang, B., Leon, L. F., Liao, J. J., Liu, R., Luo, X., et al. (2020).
 Rejoinder to letter to the editor “the hazards of period specific and
 weighted hazard ratios”. <em>Statistics in Biopharmaceutical Research</em>,
-<em>12</em>(4), 520.</p></li>
+<em>12</em>(4), 520. <a href="https://doi.org/10.1080/19466315.2020.1825522" class="uri">https://doi.org/10.1080/19466315.2020.1825522</a></p></li>
 <li><p>Tian, L., Jin, H., Uno, H., Lu, Y., Huang, B., Anderson, K. M., &amp;
 Wei, L. (2020). On the empirical choice of the time window for
-restricted mean survival time. <em>Biometrics</em>, <em>76</em>(4), 1157–1166.</p></li>
+restricted mean survival time. <em>Biometrics</em>, <em>76</em>(4), 1157–1166.
+<a href="https://doi.org/10.1111/biom.13237" class="uri">https://doi.org/10.1111/biom.13237</a></p></li>
 </ul>
 </div>
-<div id="section-2" class="section level2">
+<div id="section-3" class="section level2">
 <h2>2018</h2>
 <ul>
 <li><p>Bohula, E. A., Scirica, B. M., Inzucchi, S. E., McGuire, D. K.,
@@ -56,34 +71,50 @@ Keech, A. C., Smith, S. R., Kanevsky, E., Murphy, S. A., Leiter, L. A.,
 Dwyer, J. P., et al. (2018). Effect of lorcaserin on prevention and
 remission of type 2 diabetes in overweight and obese patients
 (CAMELLIA-TIMI 61): A randomised, placebo-controlled trial. <em>The
-Lancet</em>, <em>392</em>(10161), 2269–2279.</p></li>
+Lancet</em>, <em>392</em>(10161), 2269–2279.
+<a href="https://doi.org/10.1016/S0140-6736(18)32328-6" class="uri">https://doi.org/10.1016/S0140-6736(18)32328-6</a></p></li>
 <li><p>Chen, C., Anderson, K., Mehrotra, D. V., Rubin, E. H., &amp; Tse, A.
 (2018). A 2-in-1 adaptive phase 2/3 design for expedited oncology drug
-development. <em>Contemporary Clinical Trials</em>, <em>64</em>, 238–242.</p></li>
+development. <em>Contemporary Clinical Trials</em>, <em>64</em>, 238–242.
+<a href="https://doi.org/10.1016/j.cct.2017.09.006" class="uri">https://doi.org/10.1016/j.cct.2017.09.006</a></p></li>
 <li><p>Joseph, R. W., Elassaiss-Schaap, J., Kefford, R., Hwu, W.-J.,
 Wolchok, J. D., Joshua, A. M., Ribas, A., Hodi, F. S., Hamid, O.,
 Robert, C., et al. (2018). Baseline tumor size is an independent
 prognostic factor for overall survival in patients with melanoma treated
-with Pembrolizumab. <em>Clinical Cancer Research</em>, <em>24</em>(20), 4960–4967.</p></li>
+with Pembrolizumab. <em>Clinical Cancer Research</em>, <em>24</em>(20), 4960–4967.
+<a href="https://doi.org/10.1158/1078-0432.CCR-17-2386" class="uri">https://doi.org/10.1158/1078-0432.CCR-17-2386</a></p></li>
 <li><p>Joseph, R. W., Elassaiss-Schaap, J., Kefford, R., Hwu, W.-J.,
 Wolchok, J. D., Joshua, A. M., Ribas, A., Hodi, F. S., Hamid, O.,
 Robert, C., et al. (2018). Correction: Baseline tumor size is an
 independent prognostic factor for overall survival in patients with
 melanoma treated with Pembrolizumab. <em>Clinical Cancer Research</em>,
-<em>24</em>(23), 6098–6098.</p></li>
+<em>24</em>(23), 6098–6098. <a href="https://doi.org/10.1158/1078-0432.CCR-18-3340" class="uri">https://doi.org/10.1158/1078-0432.CCR-18-3340</a></p></li>
 <li><p>Turner, D. C., Kondic, A. G., Anderson, K. M., Robinson, A. G.,
 Garon, E. B., Riess, J. W., Jain, L., Mayawala, K., Kang, J.,
-Ebbinghaus, S. W., et al. (2018). Pembrolizumab exposure–response
+Ebbinghaus, S. W., et al. (2018). Pembrolizumab exposure-response
 assessments challenged by association of cancer cachexia and catabolic
-ClearancePembrolizumab PK/PD confounding and cancer cachexia. <em>Clinical
-Cancer Research</em>, <em>24</em>(23), 5841–5849.</p></li>
+clearance. <em>Clinical Cancer Research</em>, <em>24</em>(23), 5841–5849.
+<a href="https://doi.org/10.1158/1078-0432.CCR-18-0415" class="uri">https://doi.org/10.1158/1078-0432.CCR-18-0415</a></p></li>
 </ul>
 </div>
-<div id="section-3" class="section level2">
+<div id="section-4" class="section level2">
+<h2>2015</h2>
+<ul>
+<li>Wan, H., Ellenberg, S. S., &amp; Anderson, K. M. (2015). Stepwise
+two-stage sample size adaptation. <em>Statistics in Medicine</em>, <em>34</em>(1),
+27–38. <a href="https://doi.org/10.1002/sim.6311" class="uri">https://doi.org/10.1002/sim.6311</a></li>
+</ul>
+</div>
+<div id="section-5" class="section level2">
 <h2>2014</h2>
 <ul>
+<li><p>Anderson, K. M. (2014). Timing and frequency of interim analyses in
+confirmatory trials. In <em>Practical considerations for adaptive trial
+design and implementation</em> (pp. 115–123). Springer.
+<a href="https://doi.org/10.1007/978-1-4939-1100-4_6" class="uri">https://doi.org/10.1007/978-1-4939-1100-4_6</a></p></li>
 <li><p>He, W., Pinheiro, J., &amp; Kuznetsova, O. M. (2014). <em>Practical
-considerations for adaptive trial design and implementation</em>. Springer.</p></li>
+considerations for adaptive trial design and implementation</em>. Springer.
+<a href="https://doi.org/10.1007/978-1-4939-1100-4" class="uri">https://doi.org/10.1007/978-1-4939-1100-4</a></p></li>
 <li><p>Joseph, R. W., Elassaiss-Schaap, J., Wolchok, J. D., Joshua, A. M.,
 Ribas, A., Hodi, F. S., Hamid, O., Robert, C., Daud, A., Hwu, W.-J.,
 Kefford, R., Hersey, P., Weber, J. S., Patnaik, A., De Alwis, D. P.,
@@ -91,138 +122,174 @@ Perrone, A. M., Kang, S. P., Ebbinghaus, S., Anderson, K. M., &amp;
 Gangadhar, T. C. (2014). Baseline tumor size as an independent
 prognostic factor for overall survival in patients with metastatic
 melanoma treated with the anti-PD-1 monoclonal antibody MK-3475.
-<em>Journal of Clinical Oncology</em>, <em>32</em>(15_suppl), 3015–3015.</p></li>
+<em>Journal of Clinical Oncology</em>, <em>32</em>(15_suppl), 3015–3015.
+<a href="https://doi.org/10.1200/jco.2014.32.15_suppl.3015" class="uri">https://doi.org/10.1200/jco.2014.32.15_suppl.3015</a></p></li>
+<li><p>Zhou, J., Adewale, A., Shentu, Y., Liu, J., &amp; Anderson, K. (2014).
+Information-based sample size re-estimation in group sequential design
+for longitudinal trials. <em>Statistics in Medicine</em>, <em>33</em>(22), 3801–3814.
+<a href="https://doi.org/10.1002/sim.6192" class="uri">https://doi.org/10.1002/sim.6192</a></p></li>
 </ul>
 </div>
-<div id="section-4" class="section level2">
+<div id="section-6" class="section level2">
 <h2>2012</h2>
 <ul>
+<li><p>Anderson, K. M., Chan, I. S., &amp; Li, X. (2012). An adaptive design
+for case-driven vaccine efficacy study when incidence rate is unknown.
+<em>Statistics and Its Interface</em>, <em>5</em>(4), 391–399.
+<a href="https://doi.org/10.4310/SII.2012.v5.n4.a2" class="uri">https://doi.org/10.4310/SII.2012.v5.n4.a2</a></p></li>
 <li><p>He, W., Kuznetsova, O. M., Harmer, M., Leahy, C., Anderson, K.,
 Dossin, N., Li, L., Bolognese, J., Tymofyeyev, Y., &amp; Schindler, J.
 (2012). Practical considerations and strategies for executing adaptive
 clinical trials. <em>Drug Information Journal: DIJ/Drug Information
-Association</em>, <em>46</em>(2), 160–174.</p></li>
+Association</em>, <em>46</em>(2), 160–174.
+<a href="https://doi.org/10.1177/0092861512436580" class="uri">https://doi.org/10.1177/0092861512436580</a></p></li>
 <li><p>Liu, Q., Li, G., Anderson, K. M., &amp; Lim, P. (2012). On efficient
 two-stage adaptive designs for clinical trials with sample size
-adjustment. <em>Journal of Biopharmaceutical Statistics</em>, <em>22</em>(4), 617–640.</p></li>
+adjustment. <em>Journal of Biopharmaceutical Statistics</em>, <em>22</em>(4), 617–640.
+<a href="https://doi.org/10.1080/10543406.2012.678226" class="uri">https://doi.org/10.1080/10543406.2012.678226</a></p></li>
 </ul>
 </div>
-<div id="section-5" class="section level2">
+<div id="section-7" class="section level2">
 <h2>2011</h2>
 <ul>
 <li>Rubin, E. H., Anderson, K. M., &amp; Gause, C. K. (2011). The BATTLE
 trial: A bold step toward improving the efficiency of biomarker-based
-drug development. <em>Cancer Discovery</em>, <em>1</em>(1), 17–20.</li>
+drug development. <em>Cancer Discovery</em>, <em>1</em>(1), 17–20.
+<a href="https://doi.org/10.1158/2159-8274.CD-11-0036" class="uri">https://doi.org/10.1158/2159-8274.CD-11-0036</a></li>
 </ul>
 </div>
-<div id="section-6" class="section level2">
+<div id="section-8" class="section level2">
 <h2>2010</h2>
 <ul>
 <li><p>Anderson, K. M., &amp; Clark, J. B. (2010). Fitting spending functions.
-<em>Statistics in Medicine</em>, <em>29</em>(3), 321–327.</p></li>
+<em>Statistics in Medicine</em>, <em>29</em>(3), 321–327.
+<a href="https://doi.org/10.1002/sim.3737" class="uri">https://doi.org/10.1002/sim.3737</a></p></li>
+<li><p>Chen, Y. J., &amp; Anderson, K. M. (2010). A “MiniPool” approach for
+combined phase IIB/III trial in patients with life-threatening disease:
+An application of the closed testing principle. <em>Statistics in
+Biopharmaceutical Research</em>, <em>2</em>(1), 62–71.
+<a href="https://doi.org/10.1198/sbr.2009.0038" class="uri">https://doi.org/10.1198/sbr.2009.0038</a></p></li>
 <li><p>Gallo, P., Anderson, K., Chuang-Stein, C., Dragalin, V., Gaydos,
 B., Krams, M., &amp; Pinheiro, J. (2010). Viewpoints on the FDA draft
 adaptive designs guidance from the PhRMA working group. <em>Journal of
-Biopharmaceutical Statistics</em>, <em>20</em>(6), 1115–1124.</p></li>
+Biopharmaceutical Statistics</em>, <em>20</em>(6), 1115–1124.
+<a href="https://doi.org/10.1080/10543406.2010.514452" class="uri">https://doi.org/10.1080/10543406.2010.514452</a></p></li>
+<li><p>Rubin, E. H., &amp; Anderson, K. M. (2010). Finding the right dose for
+cancer therapeutics—can we do better? <em>Clinical Cancer Research</em>,
+<em>16</em>(4), 1085–1087. <a href="https://doi.org/10.1158/1078-0432.CCR-09-3246" class="uri">https://doi.org/10.1158/1078-0432.CCR-09-3246</a></p></li>
 </ul>
 </div>
-<div id="section-7" class="section level2">
+<div id="section-9" class="section level2">
 <h2>2009</h2>
 <ul>
 <li>Gaydos, B., Anderson, K. M., Berry, D., Burnham, N., Chuang-Stein,
 C., Dudinak, J., Fardipour, P., Gallo, P., Givens, S., Lewis, R., et al.
 (2009). Good practices for adaptive clinical trials in pharmaceutical
-product development. <em>Drug Information Journal</em>, <em>43</em>(5), 539–556.</li>
+product development. <em>Drug Information Journal</em>, <em>43</em>(5), 539–556.
+<a href="https://doi.org/10.1177/009286150904300503" class="uri">https://doi.org/10.1177/009286150904300503</a></li>
 </ul>
 </div>
-<div id="section-8" class="section level2">
+<div id="section-10" class="section level2">
 <h2>2008</h2>
 <ul>
 <li><p>Liu, Q., &amp; Anderson, K. M. (2008). On adaptive extensions of group
 sequential trials for clinical investigations. <em>Journal of the American
-Statistical Association</em>, <em>103</em>(484), 1621–1630.</p></li>
+Statistical Association</em>, <em>103</em>(484), 1621–1630.
+<a href="https://doi.org/10.1198/016214508000000986" class="uri">https://doi.org/10.1198/016214508000000986</a></p></li>
 <li><p>Liu, Q., &amp; Anderson, K. (2008). Theory of inference for adaptively
 extended group sequential designs with applications in clinical trials.
-<em>Journal of the American Statistical Association, Supplemental Archive</em>.</p></li>
+<em>Journal of the American Statistical Association, Supplemental Archive</em>.
+<a href="https://www.tandfonline.com/doi/suppl/10.1198/016214508000000986" class="uri">https://www.tandfonline.com/doi/suppl/10.1198/016214508000000986</a></p></li>
 </ul>
 </div>
-<div id="section-9" class="section level2">
+<div id="section-11" class="section level2">
 <h2>2007</h2>
 <ul>
 <li><p>Anderson, K. M. (2007). Optimal spending functions for asymmetric
 group sequential designs. <em>Biometrical Journal: Journal of Mathematical
-Methods in Biosciences</em>, <em>49</em>(3), 337–345.</p></li>
+Methods in Biosciences</em>, <em>49</em>(3), 337–345.
+<a href="https://doi.org/10.1002/bimj.200510205" class="uri">https://doi.org/10.1002/bimj.200510205</a></p></li>
 <li><p>Cohen, Y. C., Liu, K. S., Heyden, N. L., Carides, A. D., Anderson,
 K. M., Daifotis, A. G., &amp; Gann, P. H. (2007). Detection bias due to the
 effect of finasteride on prostate volume: A modeling approach for
 analysis of the Prostate Cancer Prevention Trial. <em>Journal of the
-National Cancer Institute</em>, <em>99</em>(18), 1366–1374.</p></li>
+National Cancer Institute</em>, <em>99</em>(18), 1366–1374.
+<a href="https://doi.org/10.1093/jnci/djm130" class="uri">https://doi.org/10.1093/jnci/djm130</a></p></li>
 </ul>
 </div>
-<div id="section-10" class="section level2">
+<div id="section-12" class="section level2">
 <h2>2006</h2>
 <ul>
 <li><p>Chuang-Stein, C., Anderson, K., Gallo, P., &amp; Collins, S. (2006).
 Sample size reestimation: A review and recommendations. <em>Drug
 Information Journal: DIJ/Drug Information Association</em>, <em>40</em>(4),
-475–484.</p></li>
+475–484. <a href="https://doi.org/10.1177/216847900604000413" class="uri">https://doi.org/10.1177/216847900604000413</a></p></li>
 <li><p>Gallo, P., Chuang-Stein, C., Dragalin, V., Gaydos, B., Krams, M., &amp;
 Pinheiro, J. (2006). Adaptive designs in clinical drug development—an
 executive summary of the PhRMA working group. <em>Journal of
-Biopharmaceutical Statistics</em>, <em>16</em>(3), 275–283.</p></li>
+Biopharmaceutical Statistics</em>, <em>16</em>(3), 275–283.
+<a href="https://doi.org/10.1080/10543400600614742" class="uri">https://doi.org/10.1080/10543400600614742</a></p></li>
 </ul>
 </div>
-<div id="section-11" class="section level2">
+<div id="section-13" class="section level2">
 <h2>2004</h2>
 <ul>
-<li>Liu, Q., Anderson, K. M., &amp; Pledger, G. W. (2004). Benefit–risk
+<li>Liu, Q., Anderson, K. M., &amp; Pledger, G. W. (2004). Benefit-risk
 evaluation of multi-stage adaptive designs. <em>Sequential Analysis</em>,
-<em>23</em>(3), 317–331.</li>
+<em>23</em>(3), 317–331. <a href="https://doi.org/10.1081/SQA-200027049" class="uri">https://doi.org/10.1081/SQA-200027049</a></li>
 </ul>
 </div>
-<div id="section-12" class="section level2">
+<div id="section-14" class="section level2">
 <h2>2002</h2>
 <ul>
 <li><p>Antman, E. M., Cooper, H., Gibson, C., Lemos, J. A. de, McCabe, C.,
 Giugliano, R., Coussement, P., Murphy, S., Scherer, J., Anderson, K., et
 al. (2002). Determinants of improvement in epicardial flow and
 myocardial perfusion for ST elevation myocardial infarction. Insights
-from TIMI 14 and InTIME-II. <em>European Heart Journal</em>, <em>23</em>(12), 928–933.</p></li>
+from TIMI 14 and InTIME-II. <em>European Heart Journal</em>, <em>23</em>(12), 928–933.
+<a href="https://doi.org/10.1053/euhj.2001.2964" class="uri">https://doi.org/10.1053/euhj.2001.2964</a></p></li>
 <li><p>Kereiakes, D. J., Lincoff, A. M., Anderson, K. M., Achenbach, R.,
 Patel, K., Barnathan, E., Califf, R. M., &amp; Topol, E. J. (2002).
 Abciximab survival advantage following percutaneous coronary
 intervention is predicted by clinical risk profile. <em>American Journal of
-Cardiology</em>, <em>90</em>(6), 628–630.</p></li>
+Cardiology</em>, <em>90</em>(6), 628–630.
+<a href="https://doi.org/10.1016/s0002-9149(02)02568-7" class="uri">https://doi.org/10.1016/s0002-9149(02)02568-7</a></p></li>
 </ul>
 </div>
-<div id="section-13" class="section level2">
+<div id="section-15" class="section level2">
 <h2>2001</h2>
 <ul>
 <li><p>Akkerhuis, K. M., Deckers, J. W., Lincoff, A. M., Tcheng, J. E.,
 Boersma, E., Anderson, K., Balog, C., Califf, R. M., Topol, E. J., &amp;
 Simoons, M. L. (2001). Risk of stroke associated with abciximab among
 patients undergoing percutaneous coronary intervention. <em>JAMA</em>,
-<em>286</em>(1), 78–82.</p></li>
+<em>286</em>(1), 78–82. <a href="https://doi.org/10.1001/jama.286.1.78" class="uri">https://doi.org/10.1001/jama.286.1.78</a></p></li>
 <li><p>Anderson, K. M., Califf, R. M., Stone, G. W., Neumann, F.-J.,
 Montalescot, G., Miller, D. P., Ferguson, J. J., Willerson, J. T.,
 Weisman, H. F., &amp; Topol, E. J. (2001). Long-term mortality benefit with
 abciximab in patients undergoing percutaneous coronary intervention.
-<em>Journal of the American College of Cardiology</em>, <em>37</em>(8), 2059–2065.</p></li>
+<em>Journal of the American College of Cardiology</em>, <em>37</em>(8), 2059–2065.
+<a href="https://doi.org/10.1016/s0735-1097(01)01290-6" class="uri">https://doi.org/10.1016/s0735-1097(01)01290-6</a></p></li>
+<li><p>Kereiakes, D., Anderson, K., Achenbach, R., Melsheimer, R., Kurz,
+M., &amp; Barnathan, E. (2001). Abciximab survival advantage is not
+explained by reduction in early major cardiac events: EPIC, EPILOG and
+EPISTENT 3 year analysis. <em>Circulation</em>, <em>104</em>, 87–88.</p></li>
 </ul>
 </div>
-<div id="section-14" class="section level2">
+<div id="section-16" class="section level2">
 <h2>2000</h2>
 <ul>
 <li><p>Antman, E. M., Gibson, C., Lemos, J. A. de, Giugliano, R., McCabe,
 C., Coussement, P., Menown, I., Nienaber, C., Rehders, T., Frey, M., et
 al. (2000). Combination reperfusion therapy with abciximab and reduced
 dose reteplase: Results from TIMI 14. <em>European Heart Journal</em>,
-<em>21</em>(23), 1944–1953.</p></li>
+<em>21</em>(23), 1944–1953. <a href="https://doi.org/10.1053/euhj.2000.2243" class="uri">https://doi.org/10.1053/euhj.2000.2243</a></p></li>
 <li><p>Lemos, J. A. de, Antman, E. M., Gibson, C. M., McCabe, C. H.,
 Giugliano, R. P., Murphy, S. A., Coulter, S. A., Anderson, K., Scherer,
 J., Frey, M. J., et al. (2000). Abciximab improves both epicardial flow
 and myocardial reperfusion in ST-elevation myocardial infarction:
-Observations from the TIMI 14 trial. <em>Circulation</em>, <em>101</em>(3), 239–243.</p></li>
+Observations from the TIMI 14 trial. <em>Circulation</em>, <em>101</em>(3), 239–243.
+<a href="https://doi.org/10.1161/01.cir.101.3.239" class="uri">https://doi.org/10.1161/01.cir.101.3.239</a></p></li>
 <li><p>The Abciximab in Ischemic Stroke Investigators. (2000). Abciximab
 in acute ischemic stroke: A randomized, double-blind,
 placebo-controlled, dose-escalation study. <em>Stroke</em>, <em>31</em>(3), 601–609.</p></li>
@@ -240,29 +307,41 @@ percutaneous coronary revascularization: Results from the EPILOG
 randomized trial. <em>Circulation</em>, <em>102</em>(24), 2923–2929.</p></li>
 </ul>
 </div>
-<div id="section-15" class="section level2">
+<div id="section-17" class="section level2">
 <h2>1999</h2>
 <ul>
+<li><p>Anderson, K. M., Bala, M. V., &amp; Weisman, H. F. (1999). An industry
+perspective on health economics studies. <em>The American Heart Journal</em>,
+<em>137</em>(5), S129–S132.</p></li>
 <li><p>Antman, E. M., Giugliano, R. P., Gibson, C. M., McCabe, C. H.,
 Coussement, P., Kleiman, N. S., Vahanian, A., Adgey, A. J., Menown, I.,
 Rupprecht, H.-J., et al. (1999). Abciximab facilitates the rate and
 extent of thrombolysis: Results of the thrombolysis in myocardial
 infarction (TIMI) 14 trial. <em>Circulation</em>, <em>99</em>(21), 2720–2732.</p></li>
+<li><p>Coussement, P., Antman, E., Giugliano, R., McCabe, C., Schuhwerk,
+K., Gibson, M., Scherer, J., Anderson, K., Braunwald, E., &amp; Van de Werf,
+F. (1999). Comparison of two different thrombolytic regimens with and
+without abciximab in ST-elevation myocardial infarction: Observations
+from the TIMI 14 trial. <em>Circulation</em>, <em>100</em>, 650–650.</p></li>
 <li><p>Lincoff, A. M., Tcheng, J. E., Califf, R. M., Kereiakes, D. J.,
 Kelly, T. A., Timmis, G. C., Kleiman, N. S., Booth, J. E., Balog, C.,
 Cabot, C. F., et al. (1999). Sustained suppression of ischemic
 complications of coronary intervention by platelet GP IIb/IIIa blockade
 with abciximab: One-year outcome in the EPILOG trial. <em>Circulation</em>,
 <em>99</em>(15), 1951–1958.</p></li>
+<li><p>Mauskopf, J., Bala, M., Hermiller, J., Barber, B., &amp; Anderson, K.
+(1999). TPCT2: Cost-effectiveness of abciximab in percutaneous coronary
+intervention patients: Results from a meta-analysis. <em>Value in Health</em>,
+<em>3</em>(2), 153.</p></li>
 <li><p>Topol, E. J., Mark, D. B., Lincoff, A. M., Cohen, E., Burton, J.,
 Kleiman, N., Talley, D., Sapp, S., Booth, J., Cabot, C. F., et al.
 (1999). Outcomes at 1 year and economic implications of platelet
 glycoprotein IIb/IIIa blockade in patients undergoing coronary stenting:
 Results from a multicentre randomised trial. <em>The Lancet</em>, <em>354</em>(9195),
-2019–2024.</p></li>
+2019–2024. <a href="https://doi.org/10.1016/s0140-6736(99)10018-7" class="uri">https://doi.org/10.1016/s0140-6736(99)10018-7</a></p></li>
 </ul>
 </div>
-<div id="section-16" class="section level2">
+<div id="section-18" class="section level2">
 <h2>1998</h2>
 <ul>
 <li><p>Antman, E., Giugliano, R., McCabe, C., Gibson, M., Adgey, A.,
@@ -279,6 +358,11 @@ Cabot, C. F., Anderson, K. M., Weisman, H. F., Califf, R. M., &amp; Topol,
 E. J. (1998). Abciximab therapy and unplanned coronary stent deployment:
 Favorable effects on stent use, clinical outcomes, and bleeding
 complications. <em>Circulation</em>, <em>97</em>(9), 857–864.</p></li>
+<li><p>Kereiakes, D., Berkowitz, S., Anderson, K., Simoons, M., Vahanian,
+A., Lincoff, A., Tcheng, J., Weisman, H., Califf, R., &amp; Topol, E.
+(1998). Abciximab associated thrombocytopenia: Evidence for a complex
+interaction with heparin. <em>Journal of the American College of
+Cardiology</em>, <em>31</em>, 55–55.</p></li>
 <li><p>Kleiman, N. S., Lincoff, A. M., Kereiakes, D. J., Miller, D. P.,
 Aguirre, F. V., Anderson, K. M., Weisman, H. F., Califf, R. M., &amp; Topol,
 E. J. (1998). Diabetes mellitus, glycoprotein IIb/IIIa blockade, and
@@ -291,7 +375,7 @@ intervention. <em>Journal of the American College of Cardiology</em>, <em>31</em
 54–54.</p></li>
 </ul>
 </div>
-<div id="section-17" class="section level2">
+<div id="section-19" class="section level2">
 <h2>1997</h2>
 <ul>
 <li><p>Aguirre, F., Simoons, M., Ferguson, J., FitzPatrick, S., Anderson,
@@ -299,14 +383,18 @@ K., Kern, M., &amp; Tcheng, J. (1997). Impact of contrast media on clinical
 outcomes following percutaneous coronary interventions with platelet
 glycoprotein IIb/IIIa inhibition: Meta-analysis of clinical trials with
 abciximab. <em>Circulation</em>, <em>96</em>, 898–898.</p></li>
-<li><p>CAPTURE Investigators and others. (1997). Randomized
-placebo-controlled trial of abciximab before and during coronary
-intervention in refractory angina: The CAPTURE study. <em>Lancet</em>, <em>349</em>,
-1429–1435.</p></li>
+<li><p>Blankenship, J., Anderson, K., Demko, L., Cabot, C., Kereiakes, D.,
+&amp; Aguirre, F. (1997). Decreased vascular access site bleeding after
+coronary intervention with abciximab in the EPILOG vs the EPIC trial.
+<em>Circulation</em>, <em>96</em>, 896–896.</p></li>
+<li><p>The CAPTURE Investigators. (1997). Randomised placebo-controlled
+trial of abciximab before and during coronary intervention in refractory
+unstable angina: The CAPTURE study. <em>The Lancet</em>, <em>349</em>(9063),
+1429–1435. <a href="https://doi.org/10.1016/S0140-6736(96)10452-9" class="uri">https://doi.org/10.1016/S0140-6736(96)10452-9</a></p></li>
 <li><p>The EPILOG Investigators. (1997). Platelet glycoprotein IIb/IIIa
 receptor blockade and low-dose heparin during percutaneous coronary
 revascularization. <em>New England Journal of Medicine</em>, <em>336</em>(24),
-1689–1697.</p></li>
+1689–1697. <a href="https://doi.org/10.1056/NEJM199706123362401" class="uri">https://doi.org/10.1056/NEJM199706123362401</a></p></li>
 <li><p>Gold, H., Kereiakes, D., Dinsmore, R., Martin, L., Lausten, D.,
 Broderick, T., Anderson, K., Garabedian, H., &amp; Leinbach, R. (1997). A
 randomized, placebo-controlled crossover trial of ReoPro alone or
@@ -317,6 +405,10 @@ patients with acute myocardial infarction: Preliminary results.
 J., Montague, E., Anderson, K., &amp; Topol, E. (1997). Abciximab (<span class="nocase">c7E3 Fab</span>, ReoPro) with reduced heparin dosing
 during coronary intervention: Final results of the EPILOG trial.
 <em>Journal of the American College of Cardiology</em>, <em>29</em>, 7396–7396.</p></li>
+<li><p>Lincoff, A., Tcheng, J., Anderson, K., &amp; Cabot, C. (1997). Durable
+inhibition of ischemic complications by abciximab during percutaneous
+coronary revascularization: One-year results of the EPILOG trial.
+<em>Circulation</em>, <em>96</em>, 902–902.</p></li>
 <li><p>Lincoff, A., Mark, D., Califf, R., Tcheng, J., Ellis, S.,
 DavidsonRay, L., Anderson, K., Stoner, G., &amp; Topol, E. (1997). Economic
 assessment of platelet glycoprotein IIb/IIa receptor blockade during
@@ -343,17 +435,35 @@ platelet glycoprotein IIb/IIIa receptor inhibition on distal
 embolization during percutaneous revascularization of aortocoronary
 saphenous vein grafts. <em>The American Journal of Cardiology</em>, <em>80</em>(8),
 985–988.</p></li>
+<li><p>Simoons, M., Harrington, R., Anderson, K., Deckers, J., &amp;
+VanPapendrecht, M. (1997). Small, non-Q wave myocardial infarctions
+during PTCA, are associated with increased 6 months mortality.
+<em>Circulation</em>, <em>96</em>, 163–163.</p></li>
+<li><p>Tardiff, B., Anderson, K., Cabot, C., Deckers, J., &amp; Simoons, M.
+(1997). Reduced need for coronary bypass surgery (CABG) after
+percutaneous intervention in patients treated with abciximab.
+<em>Circulation</em>, <em>96</em>, 931–931.</p></li>
+<li><p>Tcheng, J., Anderson, K., Tardiff, B., Cabot, C., Lincoff, A.,
+Califf, R., &amp; Topol, E. (1997). Reducing the risk of percutaneous
+intervention after coronary bypass surgery: Beneficial effects of
+abciximab treatment. <em>Journals of the American College of Cardiology</em>,
+<em>29</em>, 7395–7395.</p></li>
 <li><p>Topol, E. J., Ferguson, J. J., Weisman, H. F., Tcheng, J. E.,
 Ellis, S. G., Kleiman, N. S., Ivanhoe, R. J., Wang, A. L., Miller, D.
 P., Anderson, K. M., et al. (1997). Long-term protection from myocardial
 ischemic events in a randomized trial of brief integrin <em>β</em><!-- -->3
 blockade with percutaneous coronary intervention. <em>JAMA</em>, <em>278</em>(6),
-479–484.</p></li>
+479–484. <a href="https://doi.org/10.1001/jama.1997.03550060055036" class="uri">https://doi.org/10.1001/jama.1997.03550060055036</a></p></li>
 </ul>
 </div>
-<div id="section-18" class="section level2">
+<div id="section-20" class="section level2">
 <h2>1996</h2>
 <ul>
+<li><p>Aguirre, F. V., Topol, E. J., Anderson, K. M., Kleiman, N. S.,
+Weisman, H. F., FitzPatrick, S. E., &amp; Califf, R. M. (1996). Clinical
+benefit within patient subgroups receiving <span class="nocase">c7E3</span> Fab (abciximab) during percutaneous coronary
+revascularization: Subgroup analysis from the EPIC trial. <em>The Journal
+of Invasive Cardiology</em>, <em>8</em>, 21B–29B.</p></li>
 <li><p>Coller, B. S., Anderson, K. M., &amp; Weisman, H. F. (1996). The
 anti-GPIIb-IIIa agents: Fundamental and clinical aspects.
 <em>Pathophysiology of Haemostasis and Thrombosis</em>, <em>26</em>(Suppl. 4),
@@ -372,7 +482,7 @@ inhibition for prevention of ischemic complications of high-risk
 coronary angioplasty. <em>Circulation</em>, <em>94</em>(4), 629–635.</p></li>
 </ul>
 </div>
-<div id="section-19" class="section level2">
+<div id="section-21" class="section level2">
 <h2>1995</h2>
 <ul>
 <li><p>Aguirre, F. V., Topol, E. J., Ferguson, J. J., Anderson, K.,
@@ -388,6 +498,20 @@ Haemostasis</em>, <em>74</em>(07), 302–308.</p></li>
 Impact of echocardiographic left ventricular mass on mechanistic
 implications of exercise testing parameters. <em>The American Journal of
 Cardiology</em>, <em>76</em>(12), 952–956.</p></li>
+<li><p>Lefkovits, J., Stoner, G., Anderson, K., Weisman, H., &amp; Topol, E.
+(1995). Can conjunctive platelet glycoprotein IIb/IIIa receptor blockade
+improve outcomes of coronary interventions for restenotic lesions.
+<em>Circulation</em>, <em>92</em>, 2907–2907.</p></li>
+<li><p>Lefkovlts, J., Anderson, K., Weisman, H., Topol, E. J.,
+Investigators, E., et al. (1995). 711-5 mechanism of benefit of platelet
+IIb/IIIa receptor inhibition in high risk angioplasty in the EPIC trial:
+A hierarchical endpoint analysis. <em>Journal of the American College of
+Cardiology</em>, <em>25</em>(2), 81A.</p></li>
+<li><p>Moliterno, D. J., Califf, R. M., Anderson, K., Weisman, H. F., &amp;
+Topol, E. J. (1995). 935-34 special considerations for diabetics
+receiving platelet IIb/IIIa antagonists during coronary interventions:
+Results from the EPIC trialart. <em>Journal of the American College of
+Cardiology</em>, <em>25</em>(2), 155A–156A.</p></li>
 <li><p>Moliterno, D. J., Califf, R. M., Aguirre, F. V., Anderson, K.,
 Sigmon, K. N., Weisman, H. F., Topol, E. J., EPIC Study Investigators,
 et al. (1995). Effect of platelet glycoprotein IIb/IIIa integrin
@@ -401,7 +525,7 @@ directed against the platelet GPIIb/IIIa receptor. <em>Biochemical Society
 Transactions</em>, <em>23</em>(4), 1051–1057.</p></li>
 </ul>
 </div>
-<div id="section-20" class="section level2">
+<div id="section-22" class="section level2">
 <h2>1994</h2>
 <ul>
 <li><p>Cole, B. F., Gelber, R. D., &amp; Anderson, K. M. (1994). Parametric
@@ -409,7 +533,7 @@ approaches to quality-adjusted survival analysis. <em>Biometrics</em>, 621–631
 <li><p>The EPIC Investigators. (1994). Use of a monoclonal antibody
 directed against the platelet glycoprotein IIb/IIIa receptor in
 high-risk coronary angioplasty. <em>New England Journal of Medicine</em>,
-<em>330</em>(14), 956–961.</p></li>
+<em>330</em>(14), 956–961. <a href="https://doi.org/10.1056/NEJM199404073301402" class="uri">https://doi.org/10.1056/NEJM199404073301402</a></p></li>
 <li><p>Lauer, M. S., Anderson, K. M., Larson, M. G., &amp; Levy, D. (1994). A
 new method for indexing left ventricular mass for differences in body
 size. <em>The American Journal of Cardiology</em>, <em>74</em>(5), 487–491.</p></li>
@@ -420,21 +544,32 @@ dependent mechanism from the EPIC trial. <em>Circulation</em>, <em>90</em>, 214�
 (1994). Platelet-IIb/IIIa receptor inhibition during PTCA for acute
 myocardial-infarction—insights from the EPIC trial. <em>Circulation</em>, <em>90</em>,
 564–564.</p></li>
+<li><p>Moliterno, D., Califf, R., Anderson, K., Sigmon, K., Aguirre, F.,
+Weisman, H., &amp; Topol, E. (1994). Activated clotting time is increased
+during coronary interventions with platelet IIb/IIIa antagonism-results
+from the EPIC trial. <em>Journal of the American College of Cardiology</em>,
+A106–A106.</p></li>
 <li><p>Odell, P. M., Anderson, K. M., &amp; Kannel, W. B. (1994). New models
 for predicting cardiovascular events. <em>Journal of Clinical
 Epidemiology</em>, <em>47</em>(6), 583–592.</p></li>
+<li><p>Topol, E., Califf, R., Weisman, H., Anderson, K., Wang, A., &amp;
+Willerson, J. (1994). 6-month follow-up after acute-phase platelet
+IIb/IIIa integrin blockade in the epic trial-reduction in need for
+revascularization procedures. <em>Journal of the American College of
+Cardiology</em>, A60–A60.</p></li>
 <li><p>Topol, E., Califf, R., Weisman, H., Ellis, S., Tcheng, J., Worley,
 S., Ivanhoe, R., George, B., Fintel, D., Weston, M., et al. (1994).
 Randomised trial of coronary intervention with antibody against platelet
 IIb/IIIa iritegrin for reduction of clinical restenosis: Results at six
-months. <em>The Lancet</em>, <em>343</em>(8902), 881–886.</p></li>
+months. <em>The Lancet</em>, <em>343</em>(8902), 881–886.
+<a href="https://doi.org/10.1016/S0140-6736(94)90007-8" class="uri">https://doi.org/10.1016/S0140-6736(94)90007-8</a></p></li>
 <li><p>Wilson, P. W., Anderson, K. M., Harri, T., Kannel, W. B., &amp;
 Castelli, W. P. (1994). Determinants of change in total cholesterol and
-HDL-C with age: The framingham study. <em>Journal of Gerontology</em>, <em>49</em>(6),
+HDL-C with age: The Framingham Study. <em>Journal of Gerontology</em>, <em>49</em>(6),
 M252–M257.</p></li>
 </ul>
 </div>
-<div id="section-21" class="section level2">
+<div id="section-23" class="section level2">
 <h2>1993</h2>
 <ul>
 <li><p>Ellis, S. G., Tcheng, J. E., Navetta, F. I., Muller, D., Weisman,
@@ -445,10 +580,18 @@ elective coronary angioplasty. <em>Coronary Artery Disease</em>, <em>4</em>(2),
 167–175.</p></li>
 <li><p>Ho, K., Anderson, K. M., Kannel, W. B., Grossman, W., &amp; Levy, D.
 (1993). Survival after the onset of congestive heart failure in
-framingham heart study subjects. <em>Circulation</em>, <em>88</em>(1), 107–115.</p></li>
+Framingham Heart Study subjects. <em>Circulation</em>, <em>88</em>(1), 107–115.</p></li>
+<li><p>Sutton, J., &amp; Anderson, K. (1993). Body-weight and heparin dosing
+influence bleeding complications with <span class="nocase">c7E3</span>
+antiplatelet antibody. <em>Circulation</em>, <em>88</em>, 209–209.</p></li>
+<li><p>Tcheng, J., Topol, E., Kleiman, N., Ellis, S., Navetta, F., Fintel,
+D., Weisman, H., Anderson, K., Wang, A., Miller, J., et al. (1993).
+Improvement in clinical outcomes of coronary angioplasty by treatment
+with the GPIIb/IIIa inhibitor chimeric-7e3-multivariable analysis of the
+EPIC study. <em>Circulation</em>, <em>88</em>, 506–506.</p></li>
 </ul>
 </div>
-<div id="section-22" class="section level2">
+<div id="section-24" class="section level2">
 <h2>1992</h2>
 <ul>
 <li><p>Anderson, K. M., &amp; Kannel, W. B. (1992). Obesity and disease. In P.
@@ -457,15 +600,16 @@ Company.</p></li>
 <li><p>Benjamin, E. J., Levy, D., Anderson, K. M., Wolf, P. A., Plehn, J.
 F., Evans, J. C., Comai, K., Fuller, D. L., &amp; Sutton, M. S. J. (1992).
 Determinants of doppler indexes of left ventricular diastolic function
-in normal subjects (the framingham heart study). <em>The American Journal
+in normal subjects (the Framingham Heart Study). <em>The American Journal
 of Cardiology</em>, <em>70</em>(4), 508–515.</p></li>
 <li><p>Berger, C. J., Murabito, J. M., Evans, J. C., Anderson, K. M., &amp;
 Levy, D. (1992). Prognosis after first myocardial infarction: Comparison
 of Q-wave and non-Q-wave myocardial infarction in the Framingham Heart
 Study. <em>JAMA</em>, <em>268</em>(12), 1545–1551.</p></li>
 <li><p>Castelli, W. P., Anderson, K., Wilson, P. W., &amp; Levy, D. (1992).
-Lipids and risk of coronary heart disease the framingham study. <em>Annals
-of Epidemiology</em>, <em>2</em>(1-2), 23–28.</p></li>
+Lipids and risk of coronary heart disease The Framingham Study. <em>Annals
+of Epidemiology</em>, <em>2</em>(1-2), 23–28.
+<a href="https://doi.org/10.1016/1047-2797(92)90033-m" class="uri">https://doi.org/10.1016/1047-2797(92)90033-m</a></p></li>
 <li><p>Genest Jr, J., McNamara, J. R., Ordovas, J. M., Jenner, J. L.,
 Silberman, S. R., Anderson, K. M., Wilson, P. W., Salem, D. N., &amp;
 Schaefer, E. J. (1992). Lipoprotein cholesterol, apolipoprotein A-I and
@@ -473,30 +617,31 @@ B and lipoprotein (a) abnormalities in men with premature coronary
 artery disease. <em>Journal of the American College of Cardiology</em>,
 <em>19</em>(4), 792–802.</p></li>
 <li><p>Kannel, W., Anderson, K., &amp; Evans, J. (1992). Relevance of blood
-lipids in the elderly: The framingham study. <em>Cardiovasc Risk Factors</em>,
+lipids in the elderly: The Framingham Study. <em>Cardiovasc Risk Factors</em>,
 <em>2</em>, 170–179.</p></li>
 <li><p>Kannel, W. B., Anderson, K., &amp; Wilson, P. W. (1992). White blood
-cell count and cardiovascular disease: Insights from the framingham
-study. <em>JAMA</em>, <em>267</em>(9), 1253–1256.</p></li>
+cell count and cardiovascular disease: Insights from the Framingham
+Study. <em>JAMA</em>, <em>267</em>(9), 1253–1256.
+<a href="https://doi.org/10.1001/jama.1992.03480090101035" class="uri">https://doi.org/10.1001/jama.1992.03480090101035</a></p></li>
 <li><p>Kreger, B. E., Anderson, K. M., Schatzkin, A., &amp; Splansky, G. L.
 (1992). Serum cholesterol level, body mass index, and the risk of colon
-cancer. The framingham study. <em>Cancer</em>, <em>70</em>(5), 1038–1043.</p></li>
+cancer. The Framingham Study. <em>Cancer</em>, <em>70</em>(5), 1038–1043.</p></li>
 <li><p>Lauer, M. S., Anderson, K. M., &amp; Levy, D. (1992). Separate and
 joint influences of obesity and mild hypertension on left ventricular
-mass and geometry: The framingham heart study. <em>Journal of the American
+mass and geometry: The Framingham Heart Study. <em>Journal of the American
 College of Cardiology</em>, <em>19</em>(1), 130–134.</p></li>
 <li><p>Lauer, M. S., Levy, D., Anderson, K. M., &amp; Plehn, J. F. (1992). Is
 there a relationship between exercise systolic blood pressure response
-and left ventricular mass? The framingham heart study. <em>Annals of
+and left ventricular mass? The Framingham Heart Study. <em>Annals of
 Internal Medicine</em>, <em>116</em>(3), 203–210.</p></li>
 <li><p>Levy, D., Murabito, J. M., Anderson, K. M., Christiansen, J. C., &amp;
 Castelli, W. P. (1992). Echocardiographic left ventricular hypertrophy:
-Clinical characteristics. The framingham heart study. <em>Clinical and
+Clinical characteristics. The Framingham Heart Study. <em>Clinical and
 Experimental Hypertension. Part A: Theory and Practice</em>, <em>14</em>(1-2),
 85–97.</p></li>
 <li><p>O’Leary, D. H., Anderson, K. M., Wolf, P. A., Evans, J. C., &amp;
 Poehlman, H. W. (1992). Cholesterol and carotid atherosclerosis in older
-persons: The framingham study. <em>Annals of Epidemiology</em>, <em>2</em>(1-2),
+persons: The Framingham Study. <em>Annals of Epidemiology</em>, <em>2</em>(1-2),
 147–153.</p></li>
 <li><p>Odell, P. M., Anderson, K. M., &amp; D’Agostino, R. B. (1992). Maximum
 likelihood estimation for interval-censored data using a Weibull-based
@@ -504,75 +649,84 @@ accelerated failure time model. <em>Biometrics</em>, 951–959.</p></li>
 <li><p>Singer, D. E., Nathan, D. M., Anderson, K. M., Wilson, P. W., &amp;
 Evans, J. C. (1992). Association of <em>H<strong>b</strong>A</em><sub>1<em>c</em></sub> with
 prevalent cardiovascular disease in the original cohort of the
-framingham heart study. <em>Diabetes</em>, <em>41</em>(2), 202–208.</p></li>
+Framingham Heart Study. <em>Diabetes</em>, <em>41</em>(2), 202–208.</p></li>
 </ul>
 </div>
-<div id="section-23" class="section level2">
+<div id="section-25" class="section level2">
 <h2>1991</h2>
 <ul>
 <li><p>Anderson, K. M., Odell, P. M., Wilson, P. W., &amp; Kannel, W. B.
 (1991). Cardiovascular disease risk profiles. <em>American Heart Journal</em>,
-<em>121</em>(1), 293–298.</p></li>
-<li><p>Anderson, K. M. (1991). A nonproportional hazards weibull
-accelerated failure time regression model. <em>Biometrics</em>, 281–288.</p></li>
+<em>121</em>(1), 293–298. <a href="https://doi.org/10.1016/0002-8703(91)90861-b" class="uri">https://doi.org/10.1016/0002-8703(91)90861-b</a></p></li>
+<li><p>Anderson, K. M., Dumphy, D. C., &amp; Wilson, P. W. (1991). Management
+of data quality in a long-term epidemiologic study: The Framingham Heart
+Study. In <em>Data quality control theory and pragmatics</em> (pp. 57–68).</p></li>
+<li><p>Anderson, K. M. (1991). A nonproportional hazards Weibull
+accelerated failure time regression model. <em>Biometrics</em>, 281–288.
+<a href="https://doi.org/10.2307/2532512" class="uri">https://doi.org/10.2307/2532512</a></p></li>
 <li><p>Anderson, K. M., Wilson, P., Odell, P. M., &amp; Kannel, W. B. (1991).
 An updated coronary risk profile. A statement for health professionals.
 <em>Circulation</em>, <em>83</em>(1), 356–362.</p></li>
+<li><p>Benjamin, E. J., Anderson, K. M., Plehn, J. F., Comai, K., Fuller,
+D., Evans, J. C., Wolf, P. A., Sutton, M. S. J., &amp; Levy, D. (1991). The
+impact of age on left ventricular diastolic function in healthy subjects
+from the Framingham Heart Study. <em>Journal of the American College of
+Cardiology</em>, <em>17</em>(2S1), A329–A329.</p></li>
 <li><p>Galderisi, M., Anderson, K. M., Wilson, P. W., &amp; Levy, D. (1991).
 Echocardiographic evidence for the existence of a distinct diabetic
-cardiomyopathy (the framingham heart study). <em>The American Journal of
+cardiomyopathy (the Framingham Heart Study). <em>The American Journal of
 Cardiology</em>, <em>68</em>(1), 85–89.</p></li>
 <li><p>Goldberg, R. J., Bengtson, J., Chen, Z., Anderson, K. M., Locati,
 E., &amp; Levy, D. (1991). Duration of the QT interval and total and
-cardiovascular mortality in healthy persons (the framingham heart study
+cardiovascular mortality in healthy persons (The Framingham Heart Study
 experience). <em>The American Journal of Cardiology</em>, <em>67</em>(1), 55–58.</p></li>
 <li><p>Kreger, B. E., Anderson, K. M., &amp; Levy, D. (1991). QRS interval
-fails to predict coronary disease incidence: The framingham study.
+fails to predict coronary disease incidence: The Framingham Study.
 <em>Archives of Internal Medicine</em>, <em>151</em>(7), 1365–1368.</p></li>
 <li><p>Lauer, M. S., Anderson, K. M., Kannel, W. B., &amp; Levy, D. (1991).
 The impact of obesity on left ventricular mass and geometry: The
-framingham heart study. <em>JAMA</em>, <em>266</em>(2), 231–236.</p></li>
+Framingham Heart Study. <em>JAMA</em>, <em>266</em>(2), 231–236.</p></li>
 <li><p>Lauer, M. S., Anderson, K. M., &amp; Levy, D. (1991). Influence of
 contemporary versus 30-year blood pressure levels on left ventricular
-mass and geometry: The framingham heart study. <em>Journal of the American
+mass and geometry: The Framingham Heart Study. <em>Journal of the American
 College of Cardiology</em>, <em>18</em>(5), 1287–1294.</p></li>
 <li><p>Okin, P. M., Anderson, K., Levy, D., &amp; Kligfield, P. (1991). Heart
 rate adjustment of exercise-induced ST segment depression. Improved risk
-stratification in the framingham offspring study. <em>Circulation</em>,
+stratification in the Framingham Offspring Study. <em>Circulation</em>,
 <em>83</em>(3), 866–874.</p></li>
 <li><p>Silberfarb, P. M., Anderson, K. M., Rundle, A. C., Holland, J.,
 Cooper, M. R., &amp; McIntyre, O. (1991). Mood and clinical status in
 patients with multiple myeloma. <em>Journal of Clinical Oncology</em>, <em>9</em>(12),
 2219–2224.</p></li>
 <li><p>Wilson, P. W., Anderson, K. M., &amp; Castelli, W. (1991). The impact
-of triglycerides on coronary heart disease: The framingham study.
+of triglycerides on coronary heart disease: The Framingham Study.
 <em>Athero Rev</em>, <em>22</em>, 59–63.</p></li>
 <li><p>Wilson, P. W., Anderson, K. M., Castelli, W. P., &amp; Kannel, W. B.
 (1991). Twelve-year incidence of coronary heart disease in middle-aged
-adults during the era of hypertensive therapy: The framingham offspring
-study. <em>The American Journal of Medicine</em>, <em>90</em>(1), 11–16.</p></li>
+adults during the era of hypertensive therapy: The Framingham Offspring
+Study. <em>The American Journal of Medicine</em>, <em>90</em>(1), 11–16.</p></li>
 </ul>
 </div>
-<div id="section-24" class="section level2">
+<div id="section-26" class="section level2">
 <h2>1990</h2>
 <ul>
 <li><p>Ballard-Barbash, R., Schatzkin, A., Carter, C. L., Kannel, W. B.,
 Kreger, B. E., D’Agostino, R. B., Splansky, G. L., Anderson, K. M., &amp;
 Helsel, W. E. (1990). Body fat distribution and breast cancer in the
-framingham study. <em>JNCI: Journal of the National Cancer Institute</em>,
+Framingham Study. <em>JNCI: Journal of the National Cancer Institute</em>,
 <em>82</em>(4), 286–290.</p></li>
 <li><p>Ballard-Barbash, R., Schatzkin, A., Albanes, D., Schiffman, M. H.,
 Kreger, B. E., Kannel, W. B., Anderson, K. M., &amp; Helsel, W. E. (1990).
-Physical activity and risk of large bowel cancer in the framingham
-study. <em>Cancer Research</em>, <em>50</em>(12), 3610–3613.</p></li>
+Physical activity and risk of large bowel cancer in the Framingham
+Study. <em>Cancer Research</em>, <em>50</em>(12), 3610–3613.</p></li>
 <li><p>D’Agostino, R. B., Lee, M.-L., Belanger, A. J., Cupples, L. A.,
 Anderson, K., &amp; Kannel, W. B. (1990). Relation of pooled logistic
-regression to time dependent cox regression analysis: The framingham
-heart study. <em>Statistics in Medicine</em>, <em>9</em>(12), 1501–1515.</p></li>
+regression to time dependent Cox regression analysis: The Framingham
+Heart Study. <em>Statistics in Medicine</em>, <em>9</em>(12), 1501–1515.</p></li>
 <li><p>Jones, M. G., Anderson, K. M., Wilson, P. W., Kannel, W. B.,
 Wagner, N. B., &amp; Wagner, G. S. (1990). Prognostic use of a QRS scoring
 system after hospital discharge for initial acute myocardial infarction
-in the framingham cohort. <em>The American Journal of Cardiology</em>, <em>66</em>(5),
+in the Framingham cohort. <em>The American Journal of Cardiology</em>, <em>66</em>(5),
 546–550.</p></li>
 <li><p>Kaufman, H. W., McNamara, J. R., Anderson, K. M., Wilson, P. W., &amp;
 Schaefer, E. J. (1990). How reliably can compact chemistry analyzers
@@ -583,27 +737,37 @@ specificity of electrocardiographic criteria for left ventricular
 hypertrophy. <em>Circulation</em>, <em>81</em>(3), 815–820.</p></li>
 <li><p>Levy, D., Garrison, R. J., Savage, D. D., Kannel, W. B., &amp;
 Castelli, W. P. (1990). Prognostic implications of echocardiographically
-determined left ventricular mass in the framingham heart study. <em>New
-England Journal of Medicine</em>, <em>322</em>(22), 1561–1566.</p></li>
+determined left ventricular mass in the Framingham Heart Study. <em>New
+England Journal of Medicine</em>, <em>322</em>(22), 1561–1566.
+<a href="https://doi.org/10.1056/NEJM199005313222203" class="uri">https://doi.org/10.1056/NEJM199005313222203</a></p></li>
 <li><p>Levy, D., Wilson, P. W., Anderson, K. M., &amp; Castelli, W. P.
 (1990). Stratifying the patient at risk from coronary disease: New
-insights from the framingham heart study. <em>American Heart Journal</em>,
+insights from the Framingham Heart Study. <em>American Heart Journal</em>,
 <em>119</em>(3), 712–717.</p></li>
 <li><p>Murabito, J. M., Anderson, K. M., Kannel, W. B., Evans, J. C., &amp;
 Levy, D. (1990). Risk of coronary heart disease in subjects with chest
-discomfort: The framingham heart study. <em>The American Journal of
+discomfort: The Framingham Heart Study. <em>The American Journal of
 Medicine</em>, <em>89</em>(3), 297–302.</p></li>
+<li><p>Wilson, P., Kannel, W., Anderson, K., &amp; Castelli, W. (1990).
+Cholesterol and CHD in the elderly—the Framingham cohort. <em>Circulation</em>,
+<em>82</em>, 576–576.</p></li>
+<li><p>Wilson, P., &amp; Anderson, K. (1990). HDL cholesterol and
+triglycerides as risk factors for CHD. In <em>Atherosclerosis and
+cardiovascular disease</em> (pp. 609–615). Springer.</p></li>
 </ul>
 </div>
-<div id="section-25" class="section level2">
+<div id="section-27" class="section level2">
 <h2>1989</h2>
 <ul>
 <li><p>Castelli, W. P., Wilson, P. W., Levy, D., &amp; Anderson, K. (1989).
 Cardiovascular risk factors in the elderly. <em>The American Journal of
 Cardiology</em>, <em>63</em>(16), 12–19.</p></li>
+<li><p>Greipp, P. R., Coleman, M., Anderson, K., &amp; McIntyre, O. R.
+(1989). Phase II trial of amsacrine in patients with multiple myeloma.
+<em>Medical and Pediatric Oncology</em>, <em>17</em>(1), 76–78.</p></li>
 <li><p>Kreger, B. E., Anderson, K. M., &amp; Kannel, W. B. (1989). Prevalence
-of intraventricular block in the general population: The framingham
-study. <em>American Heart Journal</em>, <em>117</em>(4), 903–910.</p></li>
+of intraventricular block in the general population: The Framingham
+Study. <em>American Heart Journal</em>, <em>117</em>(4), 903–910.</p></li>
 <li><p>Preisler, H., Anderson, K., Rai, K., Cuttner, J., Yates, J.,
 DuPre, E., &amp; Holland, J. (1989). The frequency of long-term remission in
 patients with acute myelogenous leukaemia treated with conventional
@@ -613,19 +777,19 @@ follow-up time of 6 years. <em>British Journal of Haematology</em>, <em>71</em>(
 <li><p>Schatzkin, A., Carter, C. L., Green, S. B., Kreger, B. E.,
 Splansky, G. L., Anderson, K. M., Helsel, surname, &amp; Kannel, W. B.
 (1989). Is alcohol consumption related to breast cancer? Results from
-the framingham heart study. <em>JNCI: Journal of the National Cancer
+the Framingham Heart Study. <em>JNCI: Journal of the National Cancer
 Institute</em>, <em>81</em>(1), 31–35.</p></li>
 <li><p>Wilson, P. W., Christiansen, J. C., Anderson, K. M., &amp; Kannel, W.
 B. (1989). Impact of national guidelines for cholesterol risk factor
-screening: The framingham offspring study. <em>JAMA</em>, <em>262</em>(1), 41–44.</p></li>
+screening: The Framingham Offspring Study. <em>JAMA</em>, <em>262</em>(1), 41–44.</p></li>
 </ul>
 </div>
-<div id="section-26" class="section level2">
+<div id="section-28" class="section level2">
 <h2>1988</h2>
 <ul>
 <li><p>Cupples, L. A., D’Agostino, R. B., Anderson, K., &amp; Kannel, W. B.
 (1988). Comparison of baseline and repeated measure covariate techniques
-in the framingham heart study. <em>Statistics in Medicine</em>, <em>7</em>(1-2),
+in the Framingham Heart Study. <em>Statistics in Medicine</em>, <em>7</em>(1-2),
 205–218.</p></li>
 <li><p>Hands, M. E., Sia, S. B., Shook, T. L., Anderson, K., Stone, P.
 H., Levy, D., Castelli, W. P., Rutherford, J. D., Group, F. H. S., et
@@ -638,29 +802,35 @@ risk. <em>The American Journal of Cardiology</em>, <em>62</em>(1), 147–149.</p
 <li><p>Levy, D., Anderson, K. M., Savage, D. D., Kannel, W. B.,
 Christiansen, J. C., &amp; Castelli, W. P. (1988). Echocardiographically
 detected left ventricular hypertrophy: Prevalence and risk factors: The
-framingham heart study. <em>Annals of Internal Medicine</em>, <em>108</em>(1), 7–13.</p></li>
+Framingham Heart Study. <em>Annals of Internal Medicine</em>, <em>108</em>(1), 7–13.</p></li>
 <li><p>OLEARY, D., Anderson, K., Kase, C., Wolf, P., &amp; Kannel, W. (1988).
 Extracranial carotid atherosclerosis in a general population—the
-framingham study. <em>Stroke</em>, <em>19</em>, 143–143.</p></li>
+Framingham Study. <em>Stroke</em>, <em>19</em>, 143–143.</p></li>
+<li><p>Singer, D., Nathan, D., Wilson, P., &amp; Anderson, K. (1988).
+Glycated hemoglobin is associated with cardiovascular-disease in females
+of the Framingham cohort, even among non-diabetics. <em>Clinical Research</em>,
+<em>36</em>, A350–A350.</p></li>
 </ul>
 </div>
-<div id="section-27" class="section level2">
+<div id="section-29" class="section level2">
 <h2>1987</h2>
 <ul>
 <li><p>Anderson, K. M., Castelli, W. P., &amp; Levy, D. (1987). Cholesterol
-and mortality: 30 years of follow-up from the framingham study. <em>JAMA</em>,
-<em>257</em>(16), 2176–2180.</p></li>
+and mortality: 30 years of follow-up from the Framingham Study. <em>JAMA</em>,
+<em>257</em>(16), 2176–2180. <a href="https://doi.org/10.1001/jama.1987.03390160062027" class="uri">https://doi.org/10.1001/jama.1987.03390160062027</a></p></li>
 <li><p>Anderson, K. M., Wilson, P. W., Garrison, R. J., &amp; Castelli, W. P.
 (1987). Longitudinal and secular trends in lipoprotein cholesterol
-measurements in a general population sample the framingham offspring
-study. <em>Atherosclerosis</em>, <em>68</em>(1-2), 59–66.</p></li>
+measurements in a general population sample The Framingham Offspring
+Study. <em>Atherosclerosis</em>, <em>68</em>(1-2), 59–66.
+<a href="https://doi.org/10.1016/0021-9150(87)90094-3" class="uri">https://doi.org/10.1016/0021-9150(87)90094-3</a></p></li>
 <li><p>Kannel, W. B., Anderson, K., McGee, D. L., Degatano, L. S., &amp;
 Stampfer, M. J. (1987). Nonspecific electrocardiographic abnormality as
-a predictor of coronary heart disease: The framingham study. <em>American
-Heart Journal</em>, <em>113</em>(2), 370–376.</p></li>
+a predictor of coronary heart disease: The Framingham Study. <em>American
+Heart Journal</em>, <em>113</em>(2), 370–376.
+<a href="https://doi.org/10.1016/0002-8703(87)90280-8" class="uri">https://doi.org/10.1016/0002-8703(87)90280-8</a></p></li>
 <li><p>Levy, D., Savage, D. D., Garrison, R. J., Anderson, K. M., Kannel,
 W. B., &amp; Castelli, W. P. (1987). Echocardiographic criteria for left
-ventricular hypertrophy: The framingham heart study. <em>The American
+ventricular hypertrophy: The Framingham Heart Study. <em>The American
 Journal of Cardiology</em>, <em>59</em>(9), 956–960.</p></li>
 <li><p>Levy, D., Anderson, K. M., Plehn, J., Savage, D. D., Christiansen,
 J. C., &amp; Castelli, W. P. (1987). Echocardiographically determined left
@@ -669,23 +839,30 @@ ventricular arrhythmias on one-hour ambulatory electrocardiographic
 monitoring. <em>The American Journal of Cardiology</em>, <em>59</em>(8), 836–840.</p></li>
 <li><p>Levy, D., Anderson, K., Savage, D., Kannel, W., &amp; Castelli, W.
 (1987). Influence of 30 year mean blood-pressure levels on
-left-ventricular mass—the framingham heart study. <em>Journal of the
+left-ventricular mass—the Framingham Heart Study. <em>Journal of the
 American College of Cardiology</em>, <em>9</em>, A115–A115.</p></li>
 <li><p>Levy, D., Anderson, K. M., Savage, D. D., Balkus, S. A., Kannel,
 W. B., &amp; Castelli, W. P. (1987). Risk of ventricular arrhythmias in left
-ventricular hypertrophy: The framingham heart study. <em>The American
+ventricular hypertrophy: The Framingham Heart Study. <em>The American
 Journal of Cardiology</em>, <em>60</em>(7), 560–565.</p></li>
 <li><p>O’Connor, G., Anderson, K., Kannel, W., Brand, F., Christiansen,
 J., Weiss, S., &amp; Speizer, F. (1987). Prevalence and prognosis of dyspnea
-in the framingham study. <em>Chest</em>, <em>92</em>(Suppl 2), 90S.</p></li>
+in the Framingham Study. <em>Chest</em>, <em>92</em>(Suppl 2), 90S.</p></li>
 </ul>
 </div>
-<div id="section-28" class="section level2">
+<div id="section-30" class="section level2">
 <h2>1986</h2>
 <ul>
+<li><p>Anderson, K., Castelli, W., &amp; Stokes, J. (1986). Repeated measures
+of body-mass index and mortality—the Framingham study. <em>AMERICAN JOURNAL
+OF EPIDEMIOLOGY</em>, <em>124</em>, 514–514.</p></li>
 <li><p>Castelli, W. P., &amp; Anderson, K. (1986). A population at risk:
 Prevalence of high cholesterol levels in hypertensive patients in the
-framingham study. <em>The American Journal of Medicine</em>, <em>80</em>(2), 23–32.</p></li>
+Framingham Study. <em>The American Journal of Medicine</em>, <em>80</em>(2), 23–32.</p></li>
+<li><p>Levy, D., Anderson, K., Christiansen, J., &amp; STOKES, J. (1986).
+Prevalence of ventricular arrhythmias in hypertensives treated with
+b-blockers or diuretics—the Framingham Heart Study. <em>Circulation</em>, <em>74</em>,
+489–489.</p></li>
 <li><p>Olson, W., Bennett, T., Huberty, K., &amp; Anderson, K. (1986).
 Automatic detection of ventricular-fibrillation with chronically
 implanted pressure sensors. <em>Journal of the American College of
@@ -694,21 +871,30 @@ Cardiology</em>, <em>7</em>, A182–A182.</p></li>
 BECK, R. (1986). Physiological pacing based on beat-to-beat measurement
 of right ventricular dp-dt max-initial feasibility studies in man.
 <em>Journal of the American College of Cardiology</em>, <em>7</em>, A3–A3.</p></li>
+<li><p>Sobol, R. E., Mick, R., Lebien, T. W., Ozer, H., Minowada, J.,
+Anderson, K., Ellison, R. R., Cuttner, J., Morrison, A., Richards II,
+F., et al. (1986). The reproducibility of acute lymphoblastic leukemia
+phenotype determinations: Evaluation of monoclonal antibody and
+conventional hematopoietic markers. <em>Leukemia Research</em>, <em>10</em>(5),
+481–485.</p></li>
 <li><p>Wilson, P. W., Anderson, K. M., &amp; Kannel, W. B. (1986).
-Epidemiology of diabetes mellitus in the elderly: The framingham study.
+Epidemiology of diabetes mellitus in the elderly: The Framingham Study.
 <em>The American Journal of Medicine</em>, <em>80</em>(5), 3–9.</p></li>
 </ul>
 </div>
-<div id="section-29" class="section level2">
+<div id="section-31" class="section level2">
 <h2>1985</h2>
 <ul>
 <li><p>Bennett, T., Baudino, M., Bornzin, G., Anderson, K., &amp; Olson, W.
 (1985). Rate-responsive pacing using dynamic right ventricular pressure
 in heart-blocked dogs. <em>Journal of the American College of Cardiology</em>,
 <em>5</em>, 393–393.</p></li>
+<li><p>Goetzler, R., Stokes III, J., &amp; Anderson, K. (1985). Prognosis of
+subjects in the Framingham Study with rheumatic heart disease. <em>Journal
+of the American Geriatrics Society</em>, <em>33</em>(10), 693–697.</p></li>
 <li><p>Levy, D., Savage, D., Garrison, R., Balkus, S., Anderson, K.,
 Kannel, W., &amp; Castelli, W. (1985). The association of left-ventricular
-hypertrophy with ventricular arrhythmias—the framingham heart study.
+hypertrophy with ventricular arrhythmias—the Framingham Heart Study.
 <em>Circulation</em>, <em>72</em>, 46–46.</p></li>
 <li><p>Sobol, R., Royston, I., LeBien, T., Minowada, J., Anderson, K.,
 Davey, F., Cuttner, J., Schiffer, C., Ellison, R., &amp; Bloomfield, C.
@@ -718,11 +904,11 @@ monoclonal antibodies. <em>Blood</em>, <em>65</em>(3), 730–735.</p></li>
 E. (1985). Early precursors of site-specific cancers in college men and
 women. <em>Journal of the National Cancer Institute</em>, <em>74</em>(1), 43–51.</p></li>
 <li><p>Wilson, P., Kannel, W., &amp; Anderson, K. (1985). Lipids, glucose
-intolerance and vascular disease: The framingham study. <em>Monographs on
+intolerance and vascular disease: The Framingham Study. <em>Monographs on
 Atherosclerosis</em>, <em>13</em>, 1–11.</p></li>
 </ul>
 </div>
-<div id="section-30" class="section level2">
+<div id="section-32" class="section level2">
 <h2>1984</h2>
 <ul>
 <li>Whittemore, A. S., Paffenbarger Jr, R. S., Anderson, K., &amp; Lee, J.
@@ -730,24 +916,36 @@ E. (1984). Early precursors of urogenital cancers in former college men.
 <em>The Journal of Urology</em>, <em>132</em>(6), 1256–1261.</li>
 </ul>
 </div>
-<div id="section-31" class="section level2">
+<div id="section-33" class="section level2">
 <h2>1983</h2>
 <ul>
 <li><p>Anderson, K., Wilson, P., Garrison, R., &amp; Castelli, W. (1983).
-Longitudinal and secular trends in lipoproteins: The framingham
-offspring study. <em>Arterioscler Thromb</em>, <em>3</em>, 273–281.</p></li>
+Longitudinal and secular trends in lipoproteins: The Framingham
+Offspring Study. <em>Arterioscler Thromb</em>, <em>3</em>, 273–281.</p></li>
 <li><p>Whittemore, A. S., Paffenbarger Jr, R. S., Anderson, K., &amp;
 Halpern, J. (1983). Early precursors of pancreatic cancer in college
 men. <em>Journal of Chronic Diseases</em>, <em>36</em>(3), 251–256.</p></li>
 </ul>
 </div>
-<div id="section-32" class="section level2">
+<div id="section-34" class="section level2">
 <h2>1982</h2>
 <ul>
+<li><p>Anderson, K. M. (1982). <em>Moment expansions for robust statistics</em>.
+Stanford University. Department of Statistics.
+<a href="https://purl.stanford.edu/sn138ps6683" class="uri">https://purl.stanford.edu/sn138ps6683</a></p></li>
 <li><p>Anderson, K., Sobel, M., &amp; Uppuluri, V. (1982). Quota fulfillment
-times. <em>Canadian Journal of Statistics</em>, <em>10</em>(2), 73–88.</p></li>
+times. <em>Canadian Journal of Statistics</em>, <em>10</em>(2), 73–88.
+<a href="https://doi.org/10.2307/3314900" class="uri">https://doi.org/10.2307/3314900</a></p></li>
 <li><p>Whittemore, A. S., McLarty, J. W., Fortson, N., &amp; Anderson, K.
 (1982). Regression analysis of cytopathological data. <em>Biometrics</em>,
-899–905.</p></li>
+899–905. <a href="https://doi.org/10.2307/2529870" class="uri">https://doi.org/10.2307/2529870</a></p></li>
+</ul>
+</div>
+<div id="section-35" class="section level2">
+<h2>1980</h2>
+<ul>
+<li>Anderson, K., Sobel, M., &amp; Uppuluri, V. (1980). <em>Multivariate
+hypergeometric and multinomial waiting times</em>. Stanford University.
+Department of Statistics. <a href="https://purl.stanford.edu/gt383hn1006" class="uri">https://purl.stanford.edu/gt383hn1006</a></li>
 </ul>
 </div>


### PR DESCRIPTION
This PR:

- Went through the top 200-300 most cited items on Google Scholar and added the correct ones.
- Added DOI to all items published after year 2000 so that now they are rendered with a link.
- Removed the manual "recent publications" section as they are now all included.
- Added a "Download BibTeX file" link to benefit the technical users.