### PR TITLE
Add 2024 papers

### DIFF
--- a/content/keaven.bib
+++ b/content/keaven.bib
@@ -362,6 +362,15 @@
   url     = {https://community.amstat.org/biop/biopharmreport}
 }
 
+@article{anderson2024some,
+  title     = {Some group sequential trials from industry over the last 30 years},
+  author    = {Anderson, Keaven M and Zhao, Yujie and Xiao, Nan and Ge, Joy and Weisman, Harlan F},
+  journal   = {Statistics in Biopharmaceutical Research},
+  year      = {2024},
+  publisher = {Taylor \& Francis},
+  doi       = {10.1080/19466315.2024.2334354}
+}
+
 @article{antman1998abciximab,
   title     = {Abciximab ({ReoPro}) potentiates thrombolysis in {ST} elevation myocardial infarction: results of {TIMI} 14 trial},
   author    = {Antman, EM and Giugliano, RP and McCabe, CH and Gibson, CM and Adgey, AAJ and Ghali, M and Coussement, P and Anderson, KM and Scherer, J and Van de Werf, Frans and others},
@@ -2451,6 +2460,14 @@
   pages     = {M252--M257},
   year      = {1994},
   publisher = {The Gerontological Society of America}
+}
+
+@article{zhang2024prior,
+  title   = {Prior Effective Sample Size When Borrowing on the Treatment Effect Scale},
+  author  = {Zhang, Hongtao and Anderson, Keaven M and Zimmer, Zachary and Golm, Gregory and Sapre, Aditi and Ibrahim, Joseph G},
+  journal = {arXiv preprint arXiv:2404.13366},
+  year    = {2024},
+  doi     = {10.48550/arXiv.2404.13366}
 }
 
 @article{zhao2023adjusted,

--- a/content/publications.Rmd
+++ b/content/publications.Rmd
@@ -9,6 +9,7 @@ title: Publications
 ![](/images/wordcloud.png)
 
 <div class="index">
+[2024](#year2024) |
 [2023](#year2023) | [2022](#year2022) | [2021](#year2021) | [2020](#year2020) |
 [2018](#year2018) | [2016](#year2016) | [2015](#year2015) |
 [2014](#year2014) | [2012](#year2012) | [2011](#year2011) |

--- a/content/publications.html
+++ b/content/publications.html
@@ -8,7 +8,8 @@ title: Publications
 <p><a href="https://scholar.google.com/citations?user=P5Rt1VEAAAAJ&amp;hl=en">Google Scholar profile</a> | <a href="https://keaven.github.io/keaven.bib">Download BibTeX file</a></p>
 <p><img src="/images/wordcloud.png" /></p>
 <div class="index">
-<p><a href="#year2023">2023</a> | <a href="#year2022">2022</a> | <a href="#year2021">2021</a> | <a href="#year2020">2020</a> |
+<p><a href="#year2024">2024</a> |
+<a href="#year2023">2023</a> | <a href="#year2022">2022</a> | <a href="#year2021">2021</a> | <a href="#year2020">2020</a> |
 <a href="#year2018">2018</a> | <a href="#year2016">2016</a> | <a href="#year2015">2015</a> |
 <a href="#year2014">2014</a> | <a href="#year2012">2012</a> | <a href="#year2011">2011</a> |
 <a href="#year2010">2010</a> | <a href="#year2009">2009</a> | <a href="#year2008">2008</a> | <a href="#year2007">2007</a> |
@@ -23,6 +24,19 @@ title: Publications
 <style type="text/css">
 .index { font-variant-numeric: tabular-nums; }
 </style>
+<div id="year2024" class="section level2">
+<h2>2024</h2>
+<ul>
+<li><p>Anderson, K. M., Zhao, Y., Xiao, N., Ge, J., &amp; Weisman, H. F.
+(2024). Some group sequential trials from industry over the last 30
+years. <em>Statistics in Biopharmaceutical Research</em>.
+<a href="https://doi.org/10.1080/19466315.2024.2334354" class="uri">https://doi.org/10.1080/19466315.2024.2334354</a></p></li>
+<li><p>Zhang, H., Anderson, K. M., Zimmer, Z., Golm, G., Sapre, A., &amp;
+Ibrahim, J. G. (2024). Prior effective sample size when borrowing on the
+treatment effect scale. <em>arXiv Preprint arXiv:2404.13366</em>.
+<a href="https://doi.org/10.48550/arXiv.2404.13366" class="uri">https://doi.org/10.48550/arXiv.2404.13366</a></p></li>
+</ul>
+</div>
 <div id="year2023" class="section level2">
 <h2>2023</h2>
 <ul>


### PR DESCRIPTION
This PR adds 2024 papers to the publications page indexed by Google Scholar so far.