### PR TITLE
Display long title properly on blog post list page

### DIFF
--- a/themes/hugo-lithium/layouts/blog/list.html
+++ b/themes/hugo-lithium/layouts/blog/list.html
@@ -21,7 +21,11 @@
     <h2 class="archive-title">{{ .Key }}</h2>
     {{ range .Pages }}
     <article class="archive-item">
-      <a href="{{ .RelPermalink }}" class="archive-item-link">{{ .Title }}</a>
+      <a href="{{ .RelPermalink }}" class="archive-item-link">
+        <span>
+        {{ .Title }}
+        </span>
+      </a>
       <span class="archive-item-date">
         {{ .Date.Format "2006-01-02" }}
       </span>

--- a/themes/hugo-lithium/static/css/main.css
+++ b/themes/hugo-lithium/static/css/main.css
@@ -321,12 +321,17 @@ pre code {
   text-decoration: none;
   font-size: 21px;
   font-weight: 600;
+  line-height: 1.7;
   color: #222;
   padding: 5px 0;
-  border-bottom: 1px solid #ddd;
 }
 
-.archive-item-link:hover {
+.archive-item-link span {
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 5px;
+}
+
+.archive-item-link:hover span {
   border-bottom-color: #222;
 }
 
@@ -423,10 +428,10 @@ pre code {
   }
 
   .archive-item-link {
-    text-overflow: ellipsis;
-    max-width: calc(100% - 120px);
-    white-space: nowrap;
-    overflow: hidden;
+    text-overflow: "";
+    max-width: calc(100% - 160px);
+    white-space: normal;
+    overflow: visible;
   }
 
   .article-title {


### PR DESCRIPTION
This PR adds an additional `span` element and styles to make "long" titles display in full, wrapped in multiple lines properly.