### PR TITLE
Add og:image link to all blog posts

### DIFF
--- a/content/blog/2023-11-17-gsdesign-3-6-0/index.Rmd
+++ b/content/blog/2023-11-17-gsdesign-3-6-0/index.Rmd
@@ -11,6 +11,7 @@ description: >
     gsDesign 3.6.0 brings improvements including time-to-event endpoint design
     with calendar timing, integer sample size & event count conversion,
     and survival design to exact binomial bounds translation.
+meta_img: "images/to-integer.png"
 ---
 
 ```{r setup, include=FALSE}

--- a/content/blog/2023-11-17-gsdesign-3-6-0/index.html
+++ b/content/blog/2023-11-17-gsdesign-3-6-0/index.html
@@ -11,6 +11,7 @@ description: >
     gsDesign 3.6.0 brings improvements including time-to-event endpoint design
     with calendar timing, integer sample size & event count conversion,
     and survival design to exact binomial bounds translation.
+meta_img: "images/to-integer.png"
 ---
 
 

--- a/content/blog/2023-12-11-simtrial/index.Rmd
+++ b/content/blog/2023-12-11-simtrial/index.Rmd
@@ -15,6 +15,7 @@ description: >
     clinical trial simulation focusing on time-to-event endpoints.
     It supports complex trial designs, stratified populations, and
     non-proportional hazards.
+meta_img: "images/simtrial-banner.png"
 ---
 
 ```{r setup, include=FALSE}

--- a/content/blog/2023-12-11-simtrial/index.html
+++ b/content/blog/2023-12-11-simtrial/index.html
@@ -15,6 +15,7 @@ description: >
     clinical trial simulation focusing on time-to-event endpoints.
     It supports complex trial designs, stratified populations, and
     non-proportional hazards.
+meta_img: "images/simtrial-banner.png"
 ---
 
 

--- a/content/blog/2024-02-12-gsdesign2-1-1-1/index.Rmd
+++ b/content/blog/2024-02-12-gsdesign2-1-1-1/index.Rmd
@@ -10,6 +10,7 @@ tags:
 description: >
     gsDesign2 1.1.1 brings RTF table output, performance improvements, and more
     to this R package for non-proportional hazards group sequential design.
+meta_img: "images/gsDesign2-banner.png"
 ---
 
 ```{r setup, include=FALSE}

--- a/content/blog/2024-02-12-gsdesign2-1-1-1/index.html
+++ b/content/blog/2024-02-12-gsdesign2-1-1-1/index.html
@@ -10,6 +10,7 @@ tags:
 description: >
     gsDesign2 1.1.1 brings RTF table output, performance improvements, and more
     to this R package for non-proportional hazards group sequential design.
+meta_img: "images/gsDesign2-banner.png"
 ---
 
 

--- a/content/blog/2024-09-12-bshazard/index.Rmd
+++ b/content/blog/2024-09-12-bshazard/index.Rmd
@@ -18,6 +18,7 @@ description: >
     compare smoothed estimates with Kaplan-Meier curves, and validate
     model fits in survival analysis.
 bibliography: "bshazard.bib"
+meta_img: "images/sandro-katalina-sRaRlaFQolw-unsplash.jpg"
 ---
 
 ```{r, include=FALSE}

--- a/content/blog/2024-09-12-bshazard/index.html
+++ b/content/blog/2024-09-12-bshazard/index.html
@@ -18,6 +18,7 @@ description: >
     compare smoothed estimates with Kaplan-Meier curves, and validate
     model fits in survival analysis.
 bibliography: "bshazard.bib"
+meta_img: "images/sandro-katalina-sRaRlaFQolw-unsplash.jpg"
 ---
 
 


### PR DESCRIPTION
This PR is a follow up for #31 to add `og:image` link to every individual blog post.