### PR TITLE
Update contributed book chapter info in books and publications

### DIFF
--- a/content/books.md
+++ b/content/books.md
@@ -32,11 +32,7 @@ ul { padding-inline-start: 0px; list-style-type: none; }
 
 ## Contributed book chapters
 
-- [Group Sequential Design Under Non-proportional Hazards: Methodologies and Examples](https://link.springer.com/book/9783031659478)
-
-  In _Biostatistics in Biopharmaceutical Research and Development: Clinical Trial Design, Volume 1_, Springer, 2024.
-
-- [Multiple Testing in Group Sequential Design](https://link.springer.com/book/9783031659478)
+- [Group Sequential Design Under Non-proportional Hazards: Methodologies and Examples](https://doi.org/10.1007/978-3-031-65948-5_8)
 
   In _Biostatistics in Biopharmaceutical Research and Development: Clinical Trial Design, Volume 1_, Springer, 2024.
 

--- a/content/keaven.bib
+++ b/content/keaven.bib
@@ -2509,6 +2509,16 @@
   doi     = {10.48550/arXiv.2312.01723}
 }
 
+@incollection{zhao2024group,
+  title     = {Group Sequential Design Under Non-proportional Hazards: Methodologies and Examples},
+  author    = {Zhao, Yujie and Zhang, Yilong and Anderson, Keaven M},
+  booktitle = {Biostatistics in Biopharmaceutical Research and Development: Clinical Trial Design, Volume 1},
+  pages     = {219--234},
+  year      = {2024},
+  publisher = {Springer},
+  doi       = {10.1007/978-3-031-65948-5_8}
+}
+
 @article{zhou2014information,
   title     = {Information-based sample size re-estimation in group sequential design for longitudinal trials},
   author    = {Zhou, Jing and Adewale, Adeniyi and Shentu, Yue and Liu, Jiajun and Anderson, Keaven},

--- a/content/publications.html
+++ b/content/publications.html
@@ -39,6 +39,11 @@ model: A relatively simple procedure. <em>Statistics in Medicine</em>.
 Ibrahim, J. G. (2024). Prior effective sample size when borrowing on the
 treatment effect scale. <em>arXiv Preprint arXiv:2404.13366</em>.
 <a href="https://doi.org/10.48550/arXiv.2404.13366" class="uri">https://doi.org/10.48550/arXiv.2404.13366</a></p></li>
+<li><p>Zhao, Y., Zhang, Y., &amp; Anderson, K. M. (2024). Group sequential
+design under non-proportional hazards: Methodologies and examples. In
+<em>Biostatistics in biopharmaceutical research and development: Clinical
+trial design, volume 1</em> (pp. 219–234). Springer.
+<a href="https://doi.org/10.1007/978-3-031-65948-5_8" class="uri">https://doi.org/10.1007/978-3-031-65948-5_8</a></p></li>
 </ul>
 </div>
 <div id="year2023" class="section level2">


### PR DESCRIPTION
This PR updates the (now formally published) contributed book chapter information on the books page and add it to the publications page.

Removes the multiple testing chapter from the same book as Keaven's name is not actually on that chapter.