### PR TITLE
Update software and talks

### DIFF
--- a/content/software.md
+++ b/content/software.md
@@ -28,6 +28,10 @@ ul { padding-inline-start: 0px; list-style-type: none; }
   [GitHub](https://github.com/merck/gsDesign2) |
   [Documentation](https://merck.github.io/gsDesign2/)
 
+- **gsDesign2 Explorer**: web interface for group sequential design under non-proportional hazards
+
+  [rinpharma mirror](https://rinpharma.shinyapps.io/gsdesign2/)
+
 - **simtrial**: clinical trial simulation
 
   [CRAN](https://cran.r-project.org/package=simtrial) |

--- a/content/talks.md
+++ b/content/talks.md
@@ -7,6 +7,11 @@ ul { padding-inline-start: 0px; list-style-type: none; }
 .article-content > ul > li { margin-bottom: 25px; }
 </style>
 
+## 2025
+
+- [Design and simulation software for clinical trials](#)
+  - NESS 2025: The 38th New England Statistics Symposium, New Haven, CT.
+
 ## 2024
 
 - [Design Software for Pivotal Trials](/talks/design-software-pivotal-trials/)


### PR DESCRIPTION
This PR adds gsDesign2 Shiny app to the software page, and NESS 2025 talk to the talks page.