### PR TITLE
Update weighting syntax for gsDesign2 1.1.4

### DIFF
--- a/content/blog/2025-06-19-delayed-effect-simulation/index.Rmd
+++ b/content/blog/2025-06-19-delayed-effect-simulation/index.Rmd
@@ -569,9 +569,7 @@ mb_design <- gs_power_wlr(
   fail_rate = xx$fail_rate,
   analysis_time = xx$analysis$time,
   # Magirr-Burman weighting for MWLR
-  weight = function(x, arm0, arm1) {
-    wlr_weight_mb(x, arm0, arm1, tau = NULL, w_max = 2)
-  },
+  weight = list(method = "mb", param = list(tau = NULL, w_max = 2)),
   upper = gs_spending_bound,
   upar = upar_design,
   lpar = rep(-Inf, 3),
@@ -612,9 +610,7 @@ mb_design <- gs_power_wlr(
   fail_rate = xx$fail_rate,
   analysis_time = xx$analysis$time,
   # Magirr-Burman weighting for MWLR
-  weight = function(x, arm0, arm1) {
-    wlr_weight_mb(x, arm0, arm1, tau = NULL, w_max = 2)
-  },
+  weight = list(method = "mb", param = list(tau = NULL, w_max = 2)),
   upper = gs_spending_bound,
   upar = list(
     sf = gsDesign::sfLDOF, total_spend = alpha,

--- a/content/blog/2025-06-19-delayed-effect-simulation/index.Rmd
+++ b/content/blog/2025-06-19-delayed-effect-simulation/index.Rmd
@@ -40,6 +40,12 @@ knitr::opts_chunk$set(
 ![Expect delays. Photo by [Erik Mclean
 ](https://unsplash.com/photos/7lyRKyKIdJY).](images/erik-mclean-7lyRKyKIdJY-unsplash.jpg)
 
+::: {.callout}
+**Update (2025-06-27):** The way to specify weights for WLR designs
+has changed to match the new syntax in gsDesign2 1.1.4,
+which is now used to render this post.
+:::
+
 ## Overview
 
 We consider asymptotic approximations and corresponding simulations for

--- a/content/blog/2025-06-19-delayed-effect-simulation/index.html
+++ b/content/blog/2025-06-19-delayed-effect-simulation/index.html
@@ -73,6 +73,11 @@ editor_options:
 <img src="images/erik-mclean-7lyRKyKIdJY-unsplash.jpg" alt="Expect delays. Photo by Erik Mclean." />
 <div class="figcaption">Expect delays. Photo by <a href="https://unsplash.com/photos/7lyRKyKIdJY">Erik Mclean</a>.</div>
 </div>
+<div class="callout">
+<p><strong>Update (2025-06-27):</strong> The way to specify weights for WLR designs
+has changed to match the new syntax in gsDesign2 1.1.4,
+which is now used to render this post.</p>
+</div>
 <div id="overview" class="section level2">
 <h2>Overview</h2>
 <p>We consider asymptotic approximations and corresponding simulations for
@@ -1093,7 +1098,7 @@ We see that this average closely approximates the AHR values in Table 1.</p>
 } else {
   load(&quot;FixedDesignSimulation.RData&quot;)
 }</code></pre>
-<pre><code>#&gt; Fixed design simulation duration for 1e+05 simulated trials: 825.36 sec elapsed</code></pre>
+<pre><code>#&gt; Fixed design simulation duration for 1e+05 simulated trials: 770.89 sec elapsed</code></pre>
 <pre class="r"><code>sim_summary |&gt;
   transmute(
     Scenario = factor(Scenario),
@@ -1722,9 +1727,7 @@ mb_design &lt;- gs_power_wlr(
   fail_rate = xx$fail_rate,
   analysis_time = xx$analysis$time,
   # Magirr-Burman weighting for MWLR
-  weight = function(x, arm0, arm1) {
-    wlr_weight_mb(x, arm0, arm1, tau = NULL, w_max = 2)
-  },
+  weight = list(method = &quot;mb&quot;, param = list(tau = NULL, w_max = 2)),
   upper = gs_spending_bound,
   upar = upar_design,
   lpar = rep(-Inf, 3),
@@ -2266,9 +2269,7 @@ We see that this defers more spending to later analyses and increases power a bi
   fail_rate = xx$fail_rate,
   analysis_time = xx$analysis$time,
   # Magirr-Burman weighting for MWLR
-  weight = function(x, arm0, arm1) {
-    wlr_weight_mb(x, arm0, arm1, tau = NULL, w_max = 2)
-  },
+  weight = list(method = &quot;mb&quot;, param = list(tau = NULL, w_max = 2)),
   upper = gs_spending_bound,
   upar = list(
     sf = gsDesign::sfLDOF, total_spend = alpha,
@@ -4010,7 +4011,7 @@ set.seed(42)</code></pre>
 } else {
   load(&quot;DelayedEffectSimulation.RData&quot;)
 }</code></pre>
-<pre><code>#&gt; Total simulation time: 755.44 sec elapsed</code></pre>
+<pre><code>#&gt; Total simulation time: 784.91 sec elapsed</code></pre>
 <p>We wish to mimic asymptotic approximations with appropriate simulations
 for each scenario and analysis for: Spending, Events, Time, Power,
 AHR (later!), IF, and Spending time.</p>
@@ -4184,7 +4185,7 @@ R package and the simulation R package simtrial.</p>
 #&gt;  collate  English_United States.utf8
 #&gt;  ctype    English_United States.utf8
 #&gt;  tz       America/New_York
-#&gt;  date     2025-06-19
+#&gt;  date     2025-06-27
 #&gt;  pandoc   3.7.0.2 @ C:/PROGRA~3/CHOCOL~1/bin/ (via rmarkdown)
 #&gt;  quarto   NA @ C:\\PROGRA~1\\RStudio\\RESOUR~1\\app\\bin\\quarto\\bin\\quarto.exe
 #&gt; 
@@ -4197,8 +4198,8 @@ R package and the simulation R package simtrial.</p>
 #&gt;  foreach    * 1.5.2   2022-02-02 [1] CRAN (R 4.5.0)
 #&gt;  future     * 1.58.0  2025-06-05 [1] CRAN (R 4.5.0)
 #&gt;  ggplot2    * 3.5.2   2025-04-09 [1] CRAN (R 4.5.0)
-#&gt;  gsDesign   * 3.6.8   2025-05-21 [1] CRAN (R 4.5.0)
-#&gt;  gsDesign2  * 1.1.3.5 2025-06-19 [1] Github (Merck/gsDesign2@fe47965)
+#&gt;  gsDesign   * 3.6.9   2025-06-25 [1] CRAN (R 4.5.0)
+#&gt;  gsDesign2  * 1.1.4   2025-06-06 [1] CRAN (R 4.5.0)
 #&gt;  gt         * 1.0.0   2025-04-05 [1] CRAN (R 4.5.0)
 #&gt;  parallelly * 1.45.0  2025-06-02 [1] CRAN (R 4.5.0)
 #&gt;  purrr      * 1.0.4   2025-02-05 [1] CRAN (R 4.5.0)
@@ -4240,7 +4241,7 @@ Maurer, Willi, and Frank Bretz. 2013. <span>“Multiple Testing in Group Sequent
 Mukhopadhyay, Pralay, Wenmei Huang, Paul Metcalfe, Fredrik Öhrn, Mary Jenner, and Andrew Stone. 2020. <span>“Statistical and Practical Considerations in Designing of Immuno-Oncology Trials.”</span> <em>Journal of Biopharmaceutical Statistics</em> 30 (6): 1130–46.
 </div>
 <div id="ref-PFW" class="csl-entry">
-Proschan, Michael A, Dean A Follmann, and Myron A Waclawiw. 1992. <span>“Effects of Assumption Violations on Type I Error Rate in Group Sequential Monitoring.”</span> <em>Biometrics</em>, 1131–43.
+Proschan, Michael A, Dean A Follmann, and Myron A Waclawiw. 1992. <span>“Effects of Assumption Violations on Type <span>I</span> Error Rate in Group Sequential Monitoring.”</span> <em>Biometrics</em>, 1131–43.
 </div>
 <div id="ref-PLWBook" class="csl-entry">
 Proschan, Michael A., K. K. Gordon Lan, and Janet Turk Wittes. 2006. <em>Statistical Monitoring of Clinical Trials. A Unified Approach.</em> New York, NY: Springer.

--- a/themes/hugo-lithium/static/css/main.css
+++ b/themes/hugo-lithium/static/css/main.css
@@ -271,6 +271,21 @@ p.tags a:focus {
   background: #e5e5e5;
 }
 
+.article-content .callout p {
+  font-size: 1rem;
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  border-radius: 0.25rem;
+  border-left: 5px solid #CBF8DF;
+  border-right: 1px solid #e5e5e5;
+  border-top: 1px solid #e5e5e5;
+  border-bottom: 1px solid #e5e5e5;
+}
+
 .highlight {
   border-radius: 3px;
   position: relative;


### PR DESCRIPTION
For the delayed effects simulation blog post, this PR updates the weighting syntax adopted by gsDesign2 1.1.4 for WLR designs (https://github.com/Merck/gsDesign2/issues/533), so we can use the CRAN version 1.1.4 instead of a development version from GitHub.

Also re-renders the blog post with gsDesign2 1.1.4 and added a callout note about this change at the top of the post.