### PR TITLE
Add Springer book link

### DIFF
--- a/content/books.md
+++ b/content/books.md
@@ -10,11 +10,14 @@ ul { padding-inline-start: 0px; list-style-type: none; }
 
 ## Clinical trial design
 
-- [Group Sequential Design in R: A Practical Guide to the gsDesign Web Interface](https://keaven.github.io/gsd-shiny/)
+- [Group Sequential Design in R: A Practical Guide to the gsDesign Web Interface](https://link.springer.com/book/9783032315892)
 
   Learn how to use a web interface to design, explore, and optimize
   group sequential clinical trials leveraging the flexible capabilities of
   the R package gsDesign.
+
+  Springer, Use R! series, forthcoming 2026.
+  [Preprint version](https://keaven.github.io/gsd-shiny/)
 
 - [gsDesign Technical Manual](https://keaven.github.io/gsd-tech-manual/)
 


### PR DESCRIPTION
This PR adds the Springer link for the forthcoming book and moves the previous link to a separate "preprint version" title.